### PR TITLE
Added NetworkAdapter.BytesSentPersec and NetworkAdapter.BytesReceivedPersec in Linux

### DIFF
--- a/Hardware.Info/Linux/HardwareInfo.cs
+++ b/Hardware.Info/Linux/HardwareInfo.cs
@@ -441,7 +441,24 @@ namespace Hardware.Info.Linux
 
         public override List<NetworkAdapter> GetNetworkAdapterList()
         {
-            return base.GetNetworkAdapterList();
+            var networkAdapters =  base.GetNetworkAdapterList();
+            var charSeparators = new char[] { ' ' };
+
+            foreach (var networkAdapter in networkAdapters)
+            {
+                var networkAdapterUsageLast = TryReadFileLines("/proc/net/dev").FirstOrDefault(l => l.Trim().StartsWith(networkAdapter.Name))?.Trim().Split(charSeparators, StringSplitOptions.RemoveEmptyEntries).ToList();
+                Task.Delay(1000).Wait();
+                var networkAdapterUsageNow = TryReadFileLines("/proc/net/dev").FirstOrDefault(l => l.Trim().StartsWith(networkAdapter.Name))?.Trim().Split(charSeparators, StringSplitOptions.RemoveEmptyEntries).ToList();
+
+                if (networkAdapterUsageLast != null && networkAdapterUsageLast.Count > 0 &&
+                    networkAdapterUsageNow != null && networkAdapterUsageNow.Count > 0)
+                {
+                    networkAdapter.BytesReceivedPersec = Convert.ToUInt64(networkAdapterUsageNow[1]) - Convert.ToUInt64(networkAdapterUsageLast[1]);
+                    networkAdapter.BytesSentPersec = Convert.ToUInt64(networkAdapterUsageNow[9]) - Convert.ToUInt64(networkAdapterUsageLast[9]);
+                }
+            }
+
+            return networkAdapters;
         }
 
         public List<Printer> GetPrinterList()


### PR DESCRIPTION
This is the missing NetworkAdapter.BytesSentPersec and NetworkAdapter.BytesReceivedPersec for Linux. For Windows I have added it already with #3 

I have used the /proc system to read the NetworkAdapter.BytesSentPersec and NetworkAdapter.BytesReceivedPersec in Linux to make sure not to depend on an external command line tool