### PR TITLE
Add Mockable interface

### DIFF
--- a/Hardware.Info/Components/BIOS.cs
+++ b/Hardware.Info/Components/BIOS.cs
@@ -4,14 +4,14 @@ namespace Hardware.Info
 {
     public class BIOS
     {
-        public string Caption { get; internal set; } = string.Empty;
-        public string Description { get; internal set; } = string.Empty;
-        public string Manufacturer { get; internal set; } = string.Empty;
-        public string Name { get; internal set; } = string.Empty;
-        public string ReleaseDate { get; internal set; } = string.Empty;
-        public string SerialNumber { get; internal set; } = string.Empty;
-        public string SoftwareElementID { get; internal set; } = string.Empty;
-        public string Version { get; internal set; } = string.Empty;
+        public string Caption { get; set; } = string.Empty;
+        public string Description { get; set; } = string.Empty;
+        public string Manufacturer { get; set; } = string.Empty;
+        public string Name { get; set; } = string.Empty;
+        public string ReleaseDate { get; set; } = string.Empty;
+        public string SerialNumber { get; set; } = string.Empty;
+        public string SoftwareElementID { get; set; } = string.Empty;
+        public string Version { get; set; } = string.Empty;
 
         public override string ToString()
         {

--- a/Hardware.Info/Components/Battery.cs
+++ b/Hardware.Info/Components/Battery.cs
@@ -7,33 +7,33 @@ namespace Hardware.Info
         // Full charge capacity of the battery in milliwatt-hours. 
         // Comparison of the value to the DesignCapacity property determines when the battery requires replacement. 
         // A battery's end of life is typically when the FullChargeCapacity property falls below 80% of the DesignCapacity property.
-        public UInt32 FullChargeCapacity { get; internal set; }
+        public UInt32 FullChargeCapacity { get; set; }
 
         // Design capacity of the battery in milliwatt-hours.
-        public UInt32 DesignCapacity { get; internal set; }
+        public UInt32 DesignCapacity { get; set; }
 
-        public UInt16 BatteryStatus { get; internal set; }
+        public UInt16 BatteryStatus { get; set; }
 
         // Estimate of the percentage of full charge remaining
-        public UInt16 EstimatedChargeRemaining { get; internal set; }
+        public UInt16 EstimatedChargeRemaining { get; set; }
 
         // Estimate in minutes of the time to battery charge depletion under the present load conditions if the utility power is off, or lost and remains off, or a laptop is disconnected from a power source.
-        public UInt32 EstimatedRunTime { get; internal set; }
+        public UInt32 EstimatedRunTime { get; set; }
 
         // Battery's expected lifetime in minutes, assuming that the battery is fully charged. 
         // The property represents the total expected life of the battery, not its current remaining life, which is indicated by the EstimatedRunTime property.
-        public UInt32 ExpectedLife { get; internal set; }
+        public UInt32 ExpectedLife { get; set; }
 
         // Maximum time, in minutes, to fully charge the battery. 
         // The property represents the time to recharge a fully depleted battery, not the current remaining charge time, which is indicated in the TimeToFullCharge property.
-        public UInt32 MaxRechargeTime { get; internal set; }
+        public UInt32 MaxRechargeTime { get; set; }
 
         // Elapsed time in seconds since the computer system's UPS last switched to battery power, or the time since the system or UPS was last restarted, whichever is less. 
         // If the battery is "on line", 0 (zero) is returned.
-        public UInt32 TimeOnBattery { get; internal set; }
+        public UInt32 TimeOnBattery { get; set; }
 
         // Remaining time to charge the battery fully in minutes at the current charging rate and usage.
-        public UInt32 TimeToFullCharge { get; internal set; }
+        public UInt32 TimeToFullCharge { get; set; }
 
         private string batteryStatusDescription = string.Empty;
 

--- a/Hardware.Info/Components/CPU.cs
+++ b/Hardware.Info/Components/CPU.cs
@@ -5,21 +5,21 @@ namespace Hardware.Info
 {
     public class CPU
     {
-        public string Caption { get; internal set; } = string.Empty;
-        public UInt32 CurrentClockSpeed { get; internal set; }
-        public string Description { get; internal set; } = string.Empty;
-        public UInt32 L2CacheSize { get; internal set; }
-        public UInt32 L3CacheSize { get; internal set; }
-        public string Manufacturer { get; internal set; } = string.Empty;
-        public UInt32 MaxClockSpeed { get; internal set; }
-        public string Name { get; internal set; } = string.Empty;
-        public UInt32 NumberOfCores { get; internal set; }
-        public UInt32 NumberOfLogicalProcessors { get; internal set; }
-        public string ProcessorId { get; internal set; } = string.Empty;
-        public Boolean VirtualizationFirmwareEnabled { get; internal set; }
-        public Boolean VMMonitorModeExtensions { get; internal set; }
-        public UInt64 PercentProcessorTime { get; internal set; }
-        public List<CpuCore> CpuCoreList { get; internal set; } = new List<CpuCore>();
+        public string Caption { get; set; } = string.Empty;
+        public UInt32 CurrentClockSpeed { get; set; }
+        public string Description { get; set; } = string.Empty;
+        public UInt32 L2CacheSize { get; set; }
+        public UInt32 L3CacheSize { get; set; }
+        public string Manufacturer { get; set; } = string.Empty;
+        public UInt32 MaxClockSpeed { get; set; }
+        public string Name { get; set; } = string.Empty;
+        public UInt32 NumberOfCores { get; set; }
+        public UInt32 NumberOfLogicalProcessors { get; set; }
+        public string ProcessorId { get; set; } = string.Empty;
+        public Boolean VirtualizationFirmwareEnabled { get; set; }
+        public Boolean VMMonitorModeExtensions { get; set; }
+        public UInt64 PercentProcessorTime { get; set; }
+        public List<CpuCore> CpuCoreList { get; set; } = new List<CpuCore>();
 
         public override string ToString()
         {

--- a/Hardware.Info/Components/CpuCore.cs
+++ b/Hardware.Info/Components/CpuCore.cs
@@ -4,8 +4,8 @@ namespace Hardware.Info
 {
     public class CpuCore
     {
-        public string Name { get; internal set; } = string.Empty;
-        public UInt64 PercentProcessorTime { get; internal set; }
+        public string Name { get; set; } = string.Empty;
+        public UInt64 PercentProcessorTime { get; set; }
 
         public override string ToString()
         {

--- a/Hardware.Info/Components/Drive.cs
+++ b/Hardware.Info/Components/Drive.cs
@@ -5,15 +5,15 @@ namespace Hardware.Info
 {
     public class Volume
     {
-        public string Caption { get; internal set; } = string.Empty;
-        public Boolean Compressed { get; internal set; }
-        public string Description { get; internal set; } = string.Empty;
-        public string FileSystem { get; internal set; } = string.Empty;
-        public UInt64 FreeSpace { get; internal set; }
-        public string Name { get; internal set; } = string.Empty;
-        public UInt64 Size { get; internal set; }
-        public string VolumeName { get; internal set; } = string.Empty;
-        public string VolumeSerialNumber { get; internal set; } = string.Empty;
+        public string Caption { get; set; } = string.Empty;
+        public Boolean Compressed { get; set; }
+        public string Description { get; set; } = string.Empty;
+        public string FileSystem { get; set; } = string.Empty;
+        public UInt64 FreeSpace { get; set; }
+        public string Name { get; set; } = string.Empty;
+        public UInt64 Size { get; set; }
+        public string VolumeName { get; set; } = string.Empty;
+        public string VolumeSerialNumber { get; set; } = string.Empty;
 
         public override string ToString()
         {
@@ -32,18 +32,18 @@ namespace Hardware.Info
 
     public class Partition
     {
-        public List<Volume> VolumeList { get; internal set; } = new List<Volume>();
+        public List<Volume> VolumeList { get; set; } = new List<Volume>();
 
-        public Boolean Bootable { get; internal set; }
-        public Boolean BootPartition { get; internal set; }
-        public string Caption { get; internal set; } = string.Empty;
-        public string Description { get; internal set; } = string.Empty;
-        public UInt32 DiskIndex { get; internal set; }
-        public UInt32 Index { get; internal set; }
-        public string Name { get; internal set; } = string.Empty;
-        public Boolean PrimaryPartition { get; internal set; }
-        public UInt64 Size { get; internal set; }
-        public UInt64 StartingOffset { get; internal set; }
+        public Boolean Bootable { get; set; }
+        public Boolean BootPartition { get; set; }
+        public string Caption { get; set; } = string.Empty;
+        public string Description { get; set; } = string.Empty;
+        public UInt32 DiskIndex { get; set; }
+        public UInt32 Index { get; set; }
+        public string Name { get; set; } = string.Empty;
+        public Boolean PrimaryPartition { get; set; }
+        public UInt64 Size { get; set; }
+        public UInt64 StartingOffset { get; set; }
 
         public override string ToString()
         {
@@ -63,18 +63,18 @@ namespace Hardware.Info
 
     public class Drive
     {
-        public List<Partition> PartitionList { get; internal set; } = new List<Partition>();
+        public List<Partition> PartitionList { get; set; } = new List<Partition>();
 
-        public string Caption { get; internal set; } = string.Empty;
-        public string Description { get; internal set; } = string.Empty;
-        public string FirmwareRevision { get; internal set; } = string.Empty;
-        public UInt32 Index { get; internal set; }
-        public string Manufacturer { get; internal set; } = string.Empty;
-        public string Model { get; internal set; } = string.Empty;
-        public string Name { get; internal set; } = string.Empty;
-        public UInt32 Partitions { get; internal set; }
-        public string SerialNumber { get; internal set; } = string.Empty;
-        public UInt64 Size { get; internal set; }
+        public string Caption { get; set; } = string.Empty;
+        public string Description { get; set; } = string.Empty;
+        public string FirmwareRevision { get; set; } = string.Empty;
+        public UInt32 Index { get; set; }
+        public string Manufacturer { get; set; } = string.Empty;
+        public string Model { get; set; } = string.Empty;
+        public string Name { get; set; } = string.Empty;
+        public UInt32 Partitions { get; set; }
+        public string SerialNumber { get; set; } = string.Empty;
+        public UInt64 Size { get; set; }
 
         public override string ToString()
         {

--- a/Hardware.Info/Components/Keyboard.cs
+++ b/Hardware.Info/Components/Keyboard.cs
@@ -4,10 +4,10 @@ namespace Hardware.Info
 {
     public class Keyboard
     {
-        public string Caption { get; internal set; } = string.Empty;
-        public string Description { get; internal set; } = string.Empty;
-        public string Name { get; internal set; } = string.Empty;
-        public UInt16 NumberOfFunctionKeys { get; internal set; }
+        public string Caption { get; set; } = string.Empty;
+        public string Description { get; set; } = string.Empty;
+        public string Name { get; set; } = string.Empty;
+        public UInt16 NumberOfFunctionKeys { get; set; }
 
         public override string ToString()
         {

--- a/Hardware.Info/Components/Memory.cs
+++ b/Hardware.Info/Components/Memory.cs
@@ -32,12 +32,12 @@ namespace Hardware.Info
 
 	public class Memory
     {
-        public UInt64 Capacity { get; internal set; }
-		public FormFactor FormFactor { get; internal set; }
-		public string Manufacturer { get; internal set; } = string.Empty;
-        public string PartNumber { get; internal set; } = string.Empty;
-        public string SerialNumber { get; internal set; } = string.Empty;
-        public UInt32 Speed { get; internal set; }
+        public UInt64 Capacity { get; set; }
+		public FormFactor FormFactor { get; set; }
+		public string Manufacturer { get; set; } = string.Empty;
+        public string PartNumber { get; set; } = string.Empty;
+        public string SerialNumber { get; set; } = string.Empty;
+        public UInt32 Speed { get; set; }
 
         public override string ToString()
         {

--- a/Hardware.Info/Components/MemoryStatus.cs
+++ b/Hardware.Info/Components/MemoryStatus.cs
@@ -4,13 +4,13 @@ namespace Hardware.Info
 {
     public class MemoryStatus
     {
-        public ulong TotalPhysical { get; internal set; }
-        public ulong AvailablePhysical { get; internal set; }
-        public ulong TotalPageFile { get; internal set; }
-        public ulong AvailablePageFile { get; internal set; }
-        public ulong TotalVirtual { get; internal set; }
-        public ulong AvailableVirtual { get; internal set; }
-        public ulong AvailableExtendedVirtual { get; internal set; }
+        public ulong TotalPhysical { get; set; }
+        public ulong AvailablePhysical { get; set; }
+        public ulong TotalPageFile { get; set; }
+        public ulong AvailablePageFile { get; set; }
+        public ulong TotalVirtual { get; set; }
+        public ulong AvailableVirtual { get; set; }
+        public ulong AvailableExtendedVirtual { get; set; }
 
         public override string ToString()
         {

--- a/Hardware.Info/Components/Monitor.cs
+++ b/Hardware.Info/Components/Monitor.cs
@@ -4,13 +4,13 @@ namespace Hardware.Info
 {
     public class Monitor
     {
-        public string Caption { get; internal set; } = string.Empty;
-        public string Description { get; internal set; } = string.Empty;
-        public string MonitorManufacturer { get; internal set; } = string.Empty;
-        public string MonitorType { get; internal set; } = string.Empty;
-        public string Name { get; internal set; } = string.Empty;
-        public UInt32 PixelsPerXLogicalInch { get; internal set; }
-        public UInt32 PixelsPerYLogicalInch { get; internal set; }
+        public string Caption { get; set; } = string.Empty;
+        public string Description { get; set; } = string.Empty;
+        public string MonitorManufacturer { get; set; } = string.Empty;
+        public string MonitorType { get; set; } = string.Empty;
+        public string Name { get; set; } = string.Empty;
+        public UInt32 PixelsPerXLogicalInch { get; set; }
+        public UInt32 PixelsPerYLogicalInch { get; set; }
 
         public override string ToString()
         {

--- a/Hardware.Info/Components/Motherboard.cs
+++ b/Hardware.Info/Components/Motherboard.cs
@@ -4,9 +4,9 @@ namespace Hardware.Info
 {
     public class Motherboard
     {
-        public string Manufacturer { get; internal set; } = string.Empty;
-        public string Product { get; internal set; } = string.Empty;
-        public string SerialNumber { get; internal set; } = string.Empty;
+        public string Manufacturer { get; set; } = string.Empty;
+        public string Product { get; set; } = string.Empty;
+        public string SerialNumber { get; set; } = string.Empty;
 
         public override string ToString()
         {

--- a/Hardware.Info/Components/Mouse.cs
+++ b/Hardware.Info/Components/Mouse.cs
@@ -4,11 +4,11 @@ namespace Hardware.Info
 {
     public class Mouse
     {
-        public string Caption { get; internal set; } = string.Empty;
-        public string Description { get; internal set; } = string.Empty;
-        public string Manufacturer { get; internal set; } = string.Empty;
-        public string Name { get; internal set; } = string.Empty;
-        public byte NumberOfButtons { get; internal set; }
+        public string Caption { get; set; } = string.Empty;
+        public string Description { get; set; } = string.Empty;
+        public string Manufacturer { get; set; } = string.Empty;
+        public string Name { get; set; } = string.Empty;
+        public byte NumberOfButtons { get; set; }
 
         public override string ToString()
         {

--- a/Hardware.Info/Components/NetworkAdapter.cs
+++ b/Hardware.Info/Components/NetworkAdapter.cs
@@ -6,23 +6,23 @@ namespace Hardware.Info
 {
     public class NetworkAdapter
     {
-        public string AdapterType { get; internal set; } = string.Empty;
-        public string Caption { get; internal set; } = string.Empty;
-        public string Description { get; internal set; } = string.Empty;
-        public string MACAddress { get; internal set; } = string.Empty;
-        public string Manufacturer { get; internal set; } = string.Empty;
-        public string Name { get; internal set; } = string.Empty;
-        public string NetConnectionID { get; internal set; } = string.Empty;
-        public string ProductName { get; internal set; } = string.Empty;
-        public UInt64 Speed { get; internal set; }
-        public UInt64 BytesSentPersec { get; internal set; }
-        public UInt64 BytesReceivedPersec { get; internal set; }
+        public string AdapterType { get; set; } = string.Empty;
+        public string Caption { get; set; } = string.Empty;
+        public string Description { get; set; } = string.Empty;
+        public string MACAddress { get; set; } = string.Empty;
+        public string Manufacturer { get; set; } = string.Empty;
+        public string Name { get; set; } = string.Empty;
+        public string NetConnectionID { get; set; } = string.Empty;
+        public string ProductName { get; set; } = string.Empty;
+        public UInt64 Speed { get; set; }
+        public UInt64 BytesSentPersec { get; set; }
+        public UInt64 BytesReceivedPersec { get; set; }
 
-        public List<IPAddress> DefaultIPGatewayList { get; internal set; } = new List<IPAddress>();
-        public IPAddress DHCPServer { get; internal set; } = IPAddress.None;
-        public List<IPAddress> DNSServerSearchOrderList { get; internal set; } = new List<IPAddress>();
-        public List<IPAddress> IPAddressList { get; internal set; } = new List<IPAddress>();
-        public List<IPAddress> IPSubnetList { get; internal set; } = new List<IPAddress>();
+        public List<IPAddress> DefaultIPGatewayList { get; set; } = new List<IPAddress>();
+        public IPAddress DHCPServer { get; set; } = IPAddress.None;
+        public List<IPAddress> DNSServerSearchOrderList { get; set; } = new List<IPAddress>();
+        public List<IPAddress> IPAddressList { get; set; } = new List<IPAddress>();
+        public List<IPAddress> IPSubnetList { get; set; } = new List<IPAddress>();
 
         public override string ToString()
         {

--- a/Hardware.Info/Components/Printer.cs
+++ b/Hardware.Info/Components/Printer.cs
@@ -4,15 +4,15 @@ namespace Hardware.Info
 {
     public class Printer
     {
-        public string Caption { get; internal set; } = string.Empty;
-        public Boolean Default { get; internal set; }
-        public string Description { get; internal set; } = string.Empty;
-        public UInt32 HorizontalResolution { get; internal set; }
-        public Boolean Local { get; internal set; }
-        public string Name { get; internal set; } = string.Empty;
-        public Boolean Network { get; internal set; }
-        public Boolean Shared { get; internal set; }
-        public UInt32 VerticalResolution { get; internal set; }
+        public string Caption { get; set; } = string.Empty;
+        public Boolean Default { get; set; }
+        public string Description { get; set; } = string.Empty;
+        public UInt32 HorizontalResolution { get; set; }
+        public Boolean Local { get; set; }
+        public string Name { get; set; } = string.Empty;
+        public Boolean Network { get; set; }
+        public Boolean Shared { get; set; }
+        public UInt32 VerticalResolution { get; set; }
 
         public override string ToString()
         {

--- a/Hardware.Info/Components/SoundDevice.cs
+++ b/Hardware.Info/Components/SoundDevice.cs
@@ -4,11 +4,11 @@ namespace Hardware.Info
 {
     public class SoundDevice
     {
-        public string Caption { get; internal set; } = string.Empty;
-        public string Description { get; internal set; } = string.Empty;
-        public string Manufacturer { get; internal set; } = string.Empty;
-        public string Name { get; internal set; } = string.Empty;
-        public string ProductName { get; internal set; } = string.Empty;
+        public string Caption { get; set; } = string.Empty;
+        public string Description { get; set; } = string.Empty;
+        public string Manufacturer { get; set; } = string.Empty;
+        public string Name { get; set; } = string.Empty;
+        public string ProductName { get; set; } = string.Empty;
 
         public override string ToString()
         {

--- a/Hardware.Info/Components/VideoController.cs
+++ b/Hardware.Info/Components/VideoController.cs
@@ -4,22 +4,22 @@ namespace Hardware.Info
 {
     public class VideoController
     {
-        public UInt32 AdapterRAM { get; internal set; }
-        public string Caption { get; internal set; } = string.Empty;
-        public UInt32 CurrentBitsPerPixel { get; internal set; }
-        public UInt32 CurrentHorizontalResolution { get; internal set; }
-        public UInt64 CurrentNumberOfColors { get; internal set; }
-        public UInt32 CurrentRefreshRate { get; internal set; }
-        public UInt32 CurrentVerticalResolution { get; internal set; }
-        public string Description { get; internal set; } = string.Empty;
-        public string DriverDate { get; internal set; } = string.Empty;
-        public string DriverVersion { get; internal set; } = string.Empty;
-        public string Manufacturer { get; internal set; } = string.Empty;
-        public UInt32 MaxRefreshRate { get; internal set; }
-        public UInt32 MinRefreshRate { get; internal set; }
-        public string Name { get; internal set; } = string.Empty;
-        public string VideoModeDescription { get; internal set; } = string.Empty;
-        public string VideoProcessor { get; internal set; } = string.Empty;
+        public UInt32 AdapterRAM { get; set; }
+        public string Caption { get; set; } = string.Empty;
+        public UInt32 CurrentBitsPerPixel { get; set; }
+        public UInt32 CurrentHorizontalResolution { get; set; }
+        public UInt64 CurrentNumberOfColors { get; set; }
+        public UInt32 CurrentRefreshRate { get; set; }
+        public UInt32 CurrentVerticalResolution { get; set; }
+        public string Description { get; set; } = string.Empty;
+        public string DriverDate { get; set; } = string.Empty;
+        public string DriverVersion { get; set; } = string.Empty;
+        public string Manufacturer { get; set; } = string.Empty;
+        public UInt32 MaxRefreshRate { get; set; }
+        public UInt32 MinRefreshRate { get; set; }
+        public string Name { get; set; } = string.Empty;
+        public string VideoModeDescription { get; set; } = string.Empty;
+        public string VideoProcessor { get; set; } = string.Empty;
 
         public override string ToString()
         {

--- a/Hardware.Info/HardwareInfo.cs
+++ b/Hardware.Info/HardwareInfo.cs
@@ -26,23 +26,23 @@ namespace Hardware.Info
         public List<SoundDevice> SoundDeviceList { get; private set; } = new List<SoundDevice>();
         public List<VideoController> VideoControllerList { get; private set; } = new List<VideoController>();
 
-        private readonly IHardwareInfo hardwareInfo = null!;
+        private readonly IHardwareInfoRetrieval _hardwareInfoRetrieval = null!;
 
         public HardwareInfo(bool useAsteriskInWMI = true, TimeSpan? timeoutInWMI = null)
         {
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) // Environment.OSVersion.Platform == PlatformID.Win32NT)
             {
-                hardwareInfo = new Hardware.Info.Windows.HardwareInfo(timeoutInWMI) { UseAsteriskInWMI = useAsteriskInWMI };
+                _hardwareInfoRetrieval = new Hardware.Info.Windows.HardwareInfoRetrieval(timeoutInWMI) { UseAsteriskInWMI = useAsteriskInWMI };
             }
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX)) // Environment.OSVersion.Platform == PlatformID.MacOSX)
             {
-                hardwareInfo = new Hardware.Info.Mac.HardwareInfo();
+                _hardwareInfoRetrieval = new Hardware.Info.Mac.HardwareInfoRetrieval();
             }
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux)) // Environment.OSVersion.Platform == PlatformID.Unix)
             {
-                hardwareInfo = new Hardware.Info.Linux.HardwareInfo();
+                _hardwareInfoRetrieval = new Hardware.Info.Linux.HardwareInfoRetrieval();
             }
         }
 
@@ -65,21 +65,21 @@ namespace Hardware.Info
             RefreshVideoControllerList();
         }
 
-        public void RefreshMemoryStatus() => MemoryStatus = hardwareInfo.GetMemoryStatus();
+        public void RefreshMemoryStatus() => MemoryStatus = _hardwareInfoRetrieval.GetMemoryStatus();
 
-        public void RefreshBatteryList() => BatteryList = hardwareInfo.GetBatteryList();
-        public void RefreshBIOSList() => BiosList = hardwareInfo.GetBiosList();
-        public void RefreshCPUList(bool includePercentProcessorTime = true) => CpuList = hardwareInfo.GetCpuList(includePercentProcessorTime);
-        public void RefreshDriveList() => DriveList = hardwareInfo.GetDriveList();
-        public void RefreshKeyboardList() => KeyboardList = hardwareInfo.GetKeyboardList();
-        public void RefreshMemoryList() => MemoryList = hardwareInfo.GetMemoryList();
-        public void RefreshMonitorList() => MonitorList = hardwareInfo.GetMonitorList();
-        public void RefreshMotherboardList() => MotherboardList = hardwareInfo.GetMotherboardList();
-        public void RefreshMouseList() => MouseList = hardwareInfo.GetMouseList();
-        public void RefreshNetworkAdapterList(bool includeBytesPersec = true, bool includeNetworkAdapterConfiguration = true) => NetworkAdapterList = hardwareInfo.GetNetworkAdapterList(includeBytesPersec, includeNetworkAdapterConfiguration);
-        public void RefreshPrinterList() => PrinterList = hardwareInfo.GetPrinterList();
-        public void RefreshSoundDeviceList() => SoundDeviceList = hardwareInfo.GetSoundDeviceList();
-        public void RefreshVideoControllerList() => VideoControllerList = hardwareInfo.GetVideoControllerList();
+        public void RefreshBatteryList() => BatteryList = _hardwareInfoRetrieval.GetBatteryList();
+        public void RefreshBIOSList() => BiosList = _hardwareInfoRetrieval.GetBiosList();
+        public void RefreshCPUList(bool includePercentProcessorTime = true) => CpuList = _hardwareInfoRetrieval.GetCpuList(includePercentProcessorTime);
+        public void RefreshDriveList() => DriveList = _hardwareInfoRetrieval.GetDriveList();
+        public void RefreshKeyboardList() => KeyboardList = _hardwareInfoRetrieval.GetKeyboardList();
+        public void RefreshMemoryList() => MemoryList = _hardwareInfoRetrieval.GetMemoryList();
+        public void RefreshMonitorList() => MonitorList = _hardwareInfoRetrieval.GetMonitorList();
+        public void RefreshMotherboardList() => MotherboardList = _hardwareInfoRetrieval.GetMotherboardList();
+        public void RefreshMouseList() => MouseList = _hardwareInfoRetrieval.GetMouseList();
+        public void RefreshNetworkAdapterList(bool includeBytesPerSec = true, bool includeNetworkAdapterConfiguration = true) => NetworkAdapterList = _hardwareInfoRetrieval.GetNetworkAdapterList(includeBytesPerSec, includeNetworkAdapterConfiguration);
+        public void RefreshPrinterList() => PrinterList = _hardwareInfoRetrieval.GetPrinterList();
+        public void RefreshSoundDeviceList() => SoundDeviceList = _hardwareInfoRetrieval.GetSoundDeviceList();
+        public void RefreshVideoControllerList() => VideoControllerList = _hardwareInfoRetrieval.GetVideoControllerList();
 
         #region Static
 

--- a/Hardware.Info/HardwareInfo.cs
+++ b/Hardware.Info/HardwareInfo.cs
@@ -8,7 +8,7 @@ using System.Runtime.InteropServices;
 
 namespace Hardware.Info
 {
-    public class HardwareInfo
+    public class HardwareInfo : IHardwareInfo
     {
         public MemoryStatus MemoryStatus { get; private set; } = new MemoryStatus();
 

--- a/Hardware.Info/IHardwareInfo.cs
+++ b/Hardware.Info/IHardwareInfo.cs
@@ -2,22 +2,36 @@
 
 namespace Hardware.Info
 {
-    internal interface IHardwareInfo
+    public interface IHardwareInfo
     {
-        MemoryStatus GetMemoryStatus();
-
-        List<Battery> GetBatteryList();
-        List<BIOS> GetBiosList();
-        List<CPU> GetCpuList(bool includePercentProcessorTime = true);
-        List<Drive> GetDriveList();
-        List<Keyboard> GetKeyboardList();
-        List<Memory> GetMemoryList();
-        List<Monitor> GetMonitorList();
-        List<Motherboard> GetMotherboardList();
-        List<Mouse> GetMouseList();
-        List<NetworkAdapter> GetNetworkAdapterList(bool includeBytesPersec = true, bool includeNetworkAdapterConfiguration = true);
-        List<Printer> GetPrinterList();
-        List<SoundDevice> GetSoundDeviceList();
-        List<VideoController> GetVideoControllerList();
+        MemoryStatus MemoryStatus { get; }
+        List<Battery> BatteryList { get; }
+        List<BIOS> BiosList { get; }
+        List<CPU> CpuList { get; }
+        List<Drive> DriveList { get; }
+        List<Keyboard> KeyboardList { get; }
+        List<Memory> MemoryList { get; }
+        List<Monitor> MonitorList { get; }
+        List<Motherboard> MotherboardList { get; }
+        List<Mouse> MouseList { get; }
+        List<NetworkAdapter> NetworkAdapterList { get; }
+        List<Printer> PrinterList { get; }
+        List<SoundDevice> SoundDeviceList { get; }
+        List<VideoController> VideoControllerList { get; }
+        void RefreshAll();
+        void RefreshMemoryStatus();
+        void RefreshBatteryList();
+        void RefreshBIOSList();
+        void RefreshCPUList(bool includePercentProcessorTime = true);
+        void RefreshDriveList();
+        void RefreshKeyboardList();
+        void RefreshMemoryList();
+        void RefreshMonitorList();
+        void RefreshMotherboardList();
+        void RefreshMouseList();
+        void RefreshNetworkAdapterList(bool includeBytesPerSec = true, bool includeNetworkAdapterConfiguration = true);
+        void RefreshPrinterList();
+        void RefreshSoundDeviceList();
+        void RefreshVideoControllerList();
     }
 }

--- a/Hardware.Info/IHardwareInfoRetrieval.cs
+++ b/Hardware.Info/IHardwareInfoRetrieval.cs
@@ -1,0 +1,23 @@
+﻿using System.Collections.Generic;
+
+namespace Hardware.Info
+{
+    internal interface IHardwareInfoRetrieval
+    {
+        MemoryStatus GetMemoryStatus();
+
+        List<Battery> GetBatteryList();
+        List<BIOS> GetBiosList();
+        List<CPU> GetCpuList(bool includePercentProcessorTime = true);
+        List<Drive> GetDriveList();
+        List<Keyboard> GetKeyboardList();
+        List<Memory> GetMemoryList();
+        List<Monitor> GetMonitorList();
+        List<Motherboard> GetMotherboardList();
+        List<Mouse> GetMouseList();
+        List<NetworkAdapter> GetNetworkAdapterList(bool includeBytesPersec = true, bool includeNetworkAdapterConfiguration = true);
+        List<Printer> GetPrinterList();
+        List<SoundDevice> GetSoundDeviceList();
+        List<VideoController> GetVideoControllerList();
+    }
+}

--- a/Hardware.Info/Linux/HardwareInfoRetrieval.cs
+++ b/Hardware.Info/Linux/HardwareInfoRetrieval.cs
@@ -8,7 +8,7 @@ using System.Threading.Tasks;
 
 namespace Hardware.Info.Linux
 {
-    internal class HardwareInfo : HardwareInfoBase, IHardwareInfo
+    internal class HardwareInfoRetrieval : HardwareInfoBase, IHardwareInfoRetrieval
     {
         private readonly MemoryStatus memoryStatus = new MemoryStatus();
 

--- a/Hardware.Info/Mac/HardwareInfoRetrieval.cs
+++ b/Hardware.Info/Mac/HardwareInfoRetrieval.cs
@@ -16,7 +16,7 @@ using System.Threading;
 
 namespace Hardware.Info.Mac
 {
-    internal class HardwareInfo : HardwareInfoBase, IHardwareInfo
+    internal class HardwareInfoRetrieval : HardwareInfoBase, IHardwareInfoRetrieval
     {
         [DllImport("libc")]
         static extern int sysctlbyname(string name, out IntPtr oldp, ref IntPtr oldlenp, IntPtr newp, IntPtr newlen);
@@ -24,7 +24,7 @@ namespace Hardware.Info.Mac
         private readonly MemoryStatus memoryStatus = new MemoryStatus();
 
         /*
-        public HardwareInfo()
+        public HardwareInfoRetrieval()
         {
             //SystemProfiler();
 

--- a/Hardware.Info/Windows/HardwareInfoRetrieval.cs
+++ b/Hardware.Info/Windows/HardwareInfoRetrieval.cs
@@ -25,14 +25,14 @@ namespace Hardware.Info.Windows
         }
     }
 
-    internal class HardwareInfo : HardwareInfoBase, IHardwareInfo
+    internal class HardwareInfoRetrieval : HardwareInfoBase, IHardwareInfoRetrieval
     {
         public bool UseAsteriskInWMI { get; set; }
 
         readonly string _managementScope = "root\\cimv2";
         readonly EnumerationOptions _enumerationOptions = new EnumerationOptions() { ReturnImmediately = true, Rewindable = false, Timeout = EnumerationOptions.InfiniteTimeout };
 
-        public HardwareInfo(TimeSpan? enumerationOptionsTimeout = null)
+        public HardwareInfoRetrieval(TimeSpan? enumerationOptionsTimeout = null)
         {
             if (enumerationOptionsTimeout == null)
                 enumerationOptionsTimeout = EnumerationOptions.InfiniteTimeout;


### PR DESCRIPTION
This pull request is in response to this Issue: https://github.com/Jinjinov/Hardware.Info/issues/10

Changes made:
-Renamed existing internal IHardwareInfo and inheriting classes to IHardwareInfoRetrieval
-Added interface IHardwareInfo for main public class HardwareInfo to allow it to be mocked.
-Added interfaces for each of the component classes since they have internal setters for each property
-No logic changes made