### PR TITLE
Fix reporting of M1 CPU name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea
 .vs
 .vscode
 bin


### PR DESCRIPTION
Issue #32 - The code was assuming a format of `brand_string` that was unique to Intel CPUs. The Mac code has been modified to allow it to return the name of M1 CPUs, as well as returning the max/current CPU clock speed in a more correct fashion for CPUs that support it.