### PR TITLE
Fix misleading network speed values

### DIFF
--- a/Hardware.Info/Windows/HardwareInfoRetrieval.cs
+++ b/Hardware.Info/Windows/HardwareInfoRetrieval.cs
@@ -610,8 +610,11 @@ namespace Hardware.Info.Windows
 
                     foreach (ManagementBaseObject managementObject in managementObjectSearcher.Get())
                     {
-                        networkAdapter.BytesSentPersec = GetPropertyValue<ulong>(managementObject["BytesSentPersec"]);
-                        networkAdapter.BytesReceivedPersec = GetPropertyValue<ulong>(managementObject["BytesReceivedPersec"]);
+                        if (includeBytesPersec)
+                        {
+                            networkAdapter.BytesSentPersec = GetPropertyValue<ulong>(managementObject["BytesSentPersec"]);
+                            networkAdapter.BytesReceivedPersec = GetPropertyValue<ulong>(managementObject["BytesReceivedPersec"]);
+                        }
 
                         if (networkAdapter.Speed == 0 ||
                             networkAdapter.Speed == long.MaxValue)

--- a/Hardware.Info/Windows/HardwareInfoRetrieval.cs
+++ b/Hardware.Info/Windows/HardwareInfoRetrieval.cs
@@ -596,9 +596,7 @@ namespace Hardware.Info.Windows
                     Speed = GetPropertyValue<ulong>(mo["Speed"])
                 };
 
-                bool maybeInvalidSpeed = networkAdapter.Speed == 0 || networkAdapter.Speed == long.MaxValue;
-
-                if (includeBytesPersec || maybeInvalidSpeed)
+                if (includeBytesPersec)
                 {
                     // https://learn.microsoft.com/en-us/dotnet/api/system.diagnostics.performancecounter.instancename
 
@@ -610,12 +608,10 @@ namespace Hardware.Info.Windows
 
                     foreach (ManagementBaseObject managementObject in managementObjectSearcher.Get())
                     {
-                        if (includeBytesPersec)
-                        {
-                            networkAdapter.BytesSentPersec = GetPropertyValue<ulong>(managementObject["BytesSentPersec"]);
-                            networkAdapter.BytesReceivedPersec = GetPropertyValue<ulong>(managementObject["BytesReceivedPersec"]);
-                        }
+                        networkAdapter.BytesSentPersec = GetPropertyValue<ulong>(managementObject["BytesSentPersec"]);
+                        networkAdapter.BytesReceivedPersec = GetPropertyValue<ulong>(managementObject["BytesReceivedPersec"]);
 
+                        bool maybeInvalidSpeed = networkAdapter.Speed == 0 || networkAdapter.Speed == long.MaxValue;
                         if (maybeInvalidSpeed)
                         {
                             networkAdapter.Speed = GetPropertyValue<ulong>(managementObject["CurrentBandwidth"]);

--- a/Hardware.Info/Windows/HardwareInfoRetrieval.cs
+++ b/Hardware.Info/Windows/HardwareInfoRetrieval.cs
@@ -596,9 +596,9 @@ namespace Hardware.Info.Windows
                     Speed = GetPropertyValue<ulong>(mo["Speed"])
                 };
 
-                if (includeBytesPersec ||
-                    networkAdapter.Speed == 0 ||
-                    networkAdapter.Speed == long.MaxValue)
+                bool maybeInvalidSpeed = networkAdapter.Speed == 0 || networkAdapter.Speed == long.MaxValue;
+
+                if (includeBytesPersec || maybeInvalidSpeed)
                 {
                     // https://learn.microsoft.com/en-us/dotnet/api/system.diagnostics.performancecounter.instancename
 
@@ -616,8 +616,7 @@ namespace Hardware.Info.Windows
                             networkAdapter.BytesReceivedPersec = GetPropertyValue<ulong>(managementObject["BytesReceivedPersec"]);
                         }
 
-                        if (networkAdapter.Speed == 0 ||
-                            networkAdapter.Speed == long.MaxValue)
+                        if (maybeInvalidSpeed)
                         {
                             networkAdapter.Speed = GetPropertyValue<ulong>(managementObject["CurrentBandwidth"]);
                         }


### PR DESCRIPTION
As described in [issue 43](https://github.com/Jinjinov/Hardware.Info/issues/43), this pull request tries to fix the misleading values. 

It would also be possible to read the Speed completely from the Win32_PerfFormattedData_Tcpip_NetworkAdapter because there the value was always not misleading or wrong