### PR TITLE
Fix GetCpuList failing with exception on some systems

### DIFF
--- a/Hardware.Info/Windows/HardwareInfoRetrieval.cs
+++ b/Hardware.Info/Windows/HardwareInfoRetrieval.cs
@@ -288,10 +288,19 @@ namespace Hardware.Info.Windows
                                                             : "SELECT Caption, CurrentClockSpeed, Description, L2CacheSize, L3CacheSize, Manufacturer, MaxClockSpeed, Name, NumberOfCores, NumberOfLogicalProcessors, ProcessorId, SocketDesignation FROM Win32_Processor";
             using ManagementObjectSearcher mos = new ManagementObjectSearcher(_managementScope, query, _enumerationOptions);
 
-            using PerformanceCounter cpuCounter = new PerformanceCounter("Processor Information", "% Processor Performance", "_Total");
-            float processorPerformance = cpuCounter.NextValue();
-            System.Threading.Thread.Sleep(1); // the first call to NextValue() always returns 0
-            processorPerformance = cpuCounter.NextValue();
+            float processorPerformance = 100f;
+
+            try
+            {
+                using PerformanceCounter cpuCounter = new PerformanceCounter("Processor Information", "% Processor Performance", "_Total");
+                processorPerformance = cpuCounter.NextValue();
+                System.Threading.Thread.Sleep(1); // the first call to NextValue() always returns 0
+                processorPerformance = cpuCounter.NextValue();
+            }
+            catch
+            {
+                // Ignore performance counter errors and just assume that it's at 100 %
+            }
 
             uint L1InstructionCacheSize = 0;
             uint L1DataCacheSize = 0;


### PR DESCRIPTION
I have ran into an issue where the GetCpuList fails on some user's systems with following exception:

```
System.InvalidOperationException: Cannot load Counter Name data because an invalid index '' was read from the registry.
   at System.Diagnostics.PerformanceCounterLib.GetStringTable(Boolean isHelp)
   at System.Diagnostics.PerformanceCounterLib.get_NameTable()
   at System.Diagnostics.PerformanceCounterLib.get_CategoryTable()
   at System.Diagnostics.PerformanceCounterLib.CounterExists(String category, String counter, Boolean& categoryExists)
   at System.Diagnostics.PerformanceCounterLib.CounterExists(String machine, String category, String counter)
   at System.Diagnostics.PerformanceCounter.InitializeImpl()
   at System.Diagnostics.PerformanceCounter..ctor(String categoryName, String counterName, String instanceName, Boolean readOnly)
   at System.Diagnostics.PerformanceCounter..ctor(String categoryName, String counterName, String instanceName)
   at Hardware.Info.Windows.HardwareInfoRetrieval.GetCpuList(Boolean includePercentProcessorTime)
```

From reading the code this seems to be used to compute the current CPU frequency.

I have made a modification that just assumes the CPU is at 100 % if the PerformanceCounter fails to be instantiated, rather than having the entire method fail.

I'm not sure if it's the best way to resolve this problem, but it does resolve the issue.