### PR TITLE
[Proof Of Concept] Aot support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,70 @@
+name: Run Tests on all supported platforms
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Build on ${{ matrix.os }} (${{ matrix.architecture }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        architecture: [x64] # add arm64 when such runner are available
+        dotnet: ['8.x']
+      fail-fast: false
+    env: 
+      RUN_TIME: "${{ fromJson('{ \"ubuntu-latest\": \"linux-x64\", \"windows-latest\": \"win-x64\", \"macos-latest\": \"osx-x64\" }')[matrix.os] }}"
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      
+      # Setup .NET SDK
+      - name: Setup .NET SDK
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: '${{ matrix.dotnet }}'  # Adjust the version to the one required by Hardware.Info project
+          include-prerelease: false
+      
+      # Display installed .NET SDKs
+      - name: Display .NET SDK version
+        run: dotnet --info
+
+      # Run with jit
+      - name: Run tests with jit
+        shell: bash
+        run: |
+          dotnet run \
+            --project Hardware.Info.Test/Hardware.Info.Test.csproj \
+            --configuration Release \
+            -r "$RUN_TIME" \
+            --verbosity quiet \
+            -- \
+            --enable-test-mode \
+            --expected-compiler jit \
+            --expected-arch ${{ matrix.architecture }} \
+            --no-readline
+        
+      # Run with aot
+      - name: Run tests with aot
+        shell: bash
+        run: |
+          dotnet publish \
+            Hardware.Info.Test/Hardware.Info.Test.csproj \
+            --configuration Release \
+            -r "$RUN_TIME" \
+            -p PublishAot=true \
+            --verbosity quiet
+          
+          .\Hardware.Info.Test\bin\Release\net8.0\$RUN_TIME\publish\Hardware.Info.Test \
+            --enable-test-mode \
+            --expected-compiler aot \
+            --expected-arch ${{ matrix.architecture }} \
+            --no-readline

--- a/Hardware.Info.TestAot/Hardware.Info.TestAot.csproj
+++ b/Hardware.Info.TestAot/Hardware.Info.TestAot.csproj
@@ -1,0 +1,21 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0-windows</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <PublishAot>true</PublishAot>
+    <DisableRuntimeMarshalling>true</DisableRuntimeMarshalling>
+    <PublishTrimmed>true</PublishTrimmed>
+    <IsTrimmable>true</IsTrimmable>
+    <InvariantGlobalization>true</InvariantGlobalization>
+    <SelfContained>true</SelfContained>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Hardware.Info.Windows.Aot\Hardware.Info.Windows.Aot.csproj" />
+    <ProjectReference Include="..\Hardware.Info\Hardware.Info.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Hardware.Info.TestAot/Program.cs
+++ b/Hardware.Info.TestAot/Program.cs
@@ -1,0 +1,120 @@
+﻿using System;
+using System.Net.NetworkInformation;
+
+namespace Hardware.Info.TestAot
+{
+    class Program
+    {
+        static void Main(string[] _)
+        {
+            Test(true);
+
+            Test(false);
+        }
+
+        static void Test(bool test)
+        {
+            IHardwareInfo hardwareInfo = new HardwareInfo(new Hardware.Info.Windows.Aot.HardwareInfoRetrieval());
+
+            hardwareInfo.RefreshOperatingSystem();
+            hardwareInfo.RefreshMemoryStatus();
+            hardwareInfo.RefreshBatteryList();
+            hardwareInfo.RefreshBIOSList();
+            hardwareInfo.RefreshComputerSystemList();
+            hardwareInfo.RefreshCPUList(includePercentProcessorTime: test);
+            hardwareInfo.RefreshDriveList();
+            hardwareInfo.RefreshKeyboardList();
+            hardwareInfo.RefreshMemoryList();
+            hardwareInfo.RefreshMonitorList();
+            hardwareInfo.RefreshMotherboardList();
+            hardwareInfo.RefreshMouseList();
+            hardwareInfo.RefreshNetworkAdapterList(includeBytesPerSec: test, includeNetworkAdapterConfiguration: test);
+            hardwareInfo.RefreshPrinterList();
+            hardwareInfo.RefreshSoundDeviceList();
+            hardwareInfo.RefreshVideoControllerList();
+
+            //hardwareInfo.RefreshAll();
+
+            Console.WriteLine(hardwareInfo.OperatingSystem);
+
+            Console.WriteLine(hardwareInfo.MemoryStatus);
+
+            foreach (var hardware in hardwareInfo.BatteryList)
+                Console.WriteLine(hardware);
+
+            foreach (var hardware in hardwareInfo.BiosList)
+                Console.WriteLine(hardware);
+
+            foreach (var hardware in hardwareInfo.ComputerSystemList)
+                Console.WriteLine(hardware);
+
+            foreach (var cpu in hardwareInfo.CpuList)
+            {
+                Console.WriteLine(cpu);
+
+                foreach (var cpuCore in cpu.CpuCoreList)
+                    Console.WriteLine(cpuCore);
+            }
+
+            foreach (var drive in hardwareInfo.DriveList)
+            {
+                Console.WriteLine(drive);
+
+                foreach (var partition in drive.PartitionList)
+                {
+                    Console.WriteLine(partition);
+
+                    foreach (var volume in partition.VolumeList)
+                        Console.WriteLine(volume);
+                }
+            }
+
+            foreach (var hardware in hardwareInfo.KeyboardList)
+                Console.WriteLine(hardware);
+
+            foreach (var hardware in hardwareInfo.MemoryList)
+                Console.WriteLine(hardware);
+
+            foreach (var hardware in hardwareInfo.MonitorList)
+                Console.WriteLine(hardware);
+
+            foreach (var hardware in hardwareInfo.MotherboardList)
+                Console.WriteLine(hardware);
+
+            foreach (var hardware in hardwareInfo.MouseList)
+                Console.WriteLine(hardware);
+
+            foreach (var hardware in hardwareInfo.NetworkAdapterList)
+                Console.WriteLine(hardware);
+
+            foreach (var hardware in hardwareInfo.PrinterList)
+                Console.WriteLine(hardware);
+
+            foreach (var hardware in hardwareInfo.SoundDeviceList)
+                Console.WriteLine(hardware);
+
+            foreach (var hardware in hardwareInfo.VideoControllerList)
+                Console.WriteLine(hardware);
+
+            foreach (var address in HardwareInfo.GetLocalIPv4Addresses(NetworkInterfaceType.Ethernet, OperationalStatus.Up))
+                Console.WriteLine(address);
+
+            Console.WriteLine();
+
+            foreach (var address in HardwareInfo.GetLocalIPv4Addresses(NetworkInterfaceType.Wireless80211))
+                Console.WriteLine(address);
+
+            Console.WriteLine();
+
+            foreach (var address in HardwareInfo.GetLocalIPv4Addresses(OperationalStatus.Up))
+                Console.WriteLine(address);
+
+            Console.WriteLine();
+
+            foreach (var address in HardwareInfo.GetLocalIPv4Addresses())
+                Console.WriteLine(address);
+
+            Console.ReadLine();
+        }
+    }
+}

--- a/Hardware.Info.Windows.Aot/Constants.cs
+++ b/Hardware.Info.Windows.Aot/Constants.cs
@@ -1,0 +1,24 @@
+﻿using System.Runtime.InteropServices;
+using Windows.Win32;
+
+namespace Hardware.Info.Windows.Aot
+{
+    class Constants
+    {
+        public static readonly Guid CLSID_WbemLocator = new Guid(
+            0x4590f811, 0x1d3a, 0x11d0, 0x89, 0x1f, 0x00, 0xaa, 0x00, 0x4b, 0x2e, 0x24
+        );
+
+        public static readonly Guid IID_IWbemLocator = new Guid(
+            0xdc12a687, 0x737f, 0x11cf, 0x88, 0x4d, 0x00, 0xaa, 0x00, 0x4b, 0x2e, 0x24
+        );
+
+        public const int WBEM_INFINITE = unchecked((int)0xFFFFFFFF);
+        public const int RPC_C_AUTHN_WINNT = 10;
+        public const int RPC_C_AUTHZ_NONE = 0;
+
+        public const int WBEM_E_NOT_FOUND = unchecked((int)0x80041002);
+
+        public static readonly SafeHandle NullSafeHandle = new SysFreeStringSafeHandle(IntPtr.Zero, false);
+    }
+}

--- a/Hardware.Info.Windows.Aot/EnumerationOptions.cs
+++ b/Hardware.Info.Windows.Aot/EnumerationOptions.cs
@@ -1,0 +1,8 @@
+﻿namespace Hardware.Info.Windows.Aot;
+
+struct EnumerationOptions
+{
+    public bool ReturnImmediately { get; set; }
+    public bool Rewindable { get; set; }
+    public int Timeout { get; set; }
+}

--- a/Hardware.Info.Windows.Aot/Hardware.Info.Windows.Aot.csproj
+++ b/Hardware.Info.Windows.Aot/Hardware.Info.Windows.Aot.csproj
@@ -1,0 +1,26 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0-windows</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <PublishAot>true</PublishAot>
+    <DisableRuntimeMarshalling>true</DisableRuntimeMarshalling>
+    <PublishTrimmed>true</PublishTrimmed>
+    <IsTrimmable>true</IsTrimmable>
+    <InvariantGlobalization>true</InvariantGlobalization>
+    <IsAotCompatible>true</IsAotCompatible>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Windows.CsWin32" Version="0.3.106">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Hardware.Info\Hardware.Info.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Hardware.Info.Windows.Aot/HardwareInfoRetrievalWindowsAot.cs
+++ b/Hardware.Info.Windows.Aot/HardwareInfoRetrievalWindowsAot.cs
@@ -1,0 +1,838 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Drawing;
+using System.Linq;
+using System.Management;
+using System.Net;
+using System.Runtime.InteropServices;
+using System.Security;
+using System.Text;
+using Windows.Win32;
+using Windows.Win32.Foundation;
+using Windows.Win32.Security;
+using Windows.Win32.System.Com;
+using Windows.Win32.System.SystemInformation;
+
+namespace Hardware.Info.Windows.Aot
+{
+    public class HardwareInfoRetrieval : HardwareInfoBase, IHardwareInfoRetrieval
+    {
+        private readonly MemoryStatus _memoryStatus = new MemoryStatus();
+
+        private readonly OS _os = new OS();
+
+        public bool UseAsteriskInWMI { get; set; }
+
+        private readonly string _managementScope = "root\\cimv2";
+        private readonly string _managementScopeWmi = "root\\wmi";
+        private readonly int _timeout;
+
+        public HardwareInfoRetrieval(TimeSpan? enumerationOptionsTimeout = null)
+        {
+            InitializeCom();
+
+            _timeout = enumerationOptionsTimeout.HasValue ? (int)enumerationOptionsTimeout.Value.TotalMilliseconds : Constants.WBEM_INFINITE;
+
+
+            GetOs();
+        }
+
+        public static Version? GetOsVersionByRtlGetVersion()
+        {
+            global::Windows.Win32.System.SystemInformation.OSVERSIONINFOW info = new ();
+            info.dwOSVersionInfoSize = (uint)Marshal.SizeOf<global::Windows.Win32.System.SystemInformation.OSVERSIONINFOW>();
+
+            var result = global::Windows.Wdk.PInvoke.RtlGetVersion(ref info);
+
+            return (result.SeverityCode == NTSTATUS.Severity.Success)
+                ? new Version((int)info.dwMajorVersion, (int)info.dwMinorVersion, (int)info.dwBuildNumber)
+                : null;
+        }
+
+        private unsafe void InitializeCom()
+        {
+            HRESULT hr = PInvoke.CoInitializeEx((void*)0, COINIT.COINIT_MULTITHREADED);
+
+            hr.ThrowOnFailure();
+            if (hr.Failed)
+            {
+                Console.WriteLine($"Failed to initialize COM library. Error code = 0x{hr:X}");
+                return;
+            }
+
+            // Set COM security levels
+            hr = PInvoke.CoInitializeSecurity(
+                new PSECURITY_DESCRIPTOR((void*)0),
+                -1,
+                (SOLE_AUTHENTICATION_SERVICE*)0,
+                (void*)0,
+                RPC_C_AUTHN_LEVEL.RPC_C_AUTHN_LEVEL_DEFAULT,
+                RPC_C_IMP_LEVEL.RPC_C_IMP_LEVEL_IMPERSONATE,
+                (void*)0,
+                EOLE_AUTHENTICATION_CAPABILITIES.EOAC_NONE,
+                (void*)0
+            );
+
+            if (hr.Failed)
+            {
+                Console.WriteLine($"Failed to initialize security. Error code = 0x{hr:X}");
+                PInvoke.CoUninitialize();
+                return;
+            }
+        }
+
+        public void GetOs()
+        {
+            string queryString = UseAsteriskInWMI ? "SELECT * FROM Win32_OperatingSystem"
+                                                  : "SELECT Caption, Version FROM Win32_OperatingSystem";
+            using ManagementObjectSearcher mos = new ManagementObjectSearcher(_managementScope, queryString, _timeout);
+
+            foreach (var mo in mos.Get())
+            {
+                _os.Name = mo.GetProperty<string>("Caption");
+                _os.VersionString = mo.GetProperty<string>("Version");
+
+                if (Version.TryParse(_os.VersionString, out Version version))
+                    _os.Version = version;
+            }
+
+            if (string.IsNullOrEmpty(_os.Name))
+            {
+                _os.Name = "Windows";
+            }
+
+            if (string.IsNullOrEmpty(_os.VersionString))
+            {
+                Version? version = GetOsVersionByRtlGetVersion();
+
+                if (version != null)
+                {
+                    _os.Version = version;
+                    _os.VersionString = version.ToString();
+                }
+            }
+        }
+
+        public OS GetOperatingSystem()
+        {
+            return _os;
+        }
+
+        public MemoryStatus GetMemoryStatus()
+        {
+            var _memoryStatusEx = new global::Windows.Win32.System.SystemInformation.MEMORYSTATUSEX();
+            _memoryStatusEx.dwLength = (uint)Marshal.SizeOf<global::Windows.Win32.System.SystemInformation.MEMORYSTATUSEX>();
+
+            if (PInvoke.GlobalMemoryStatusEx(ref _memoryStatusEx))
+            {
+                _memoryStatus.TotalPhysical = _memoryStatusEx.ullTotalPhys;
+                _memoryStatus.AvailablePhysical = _memoryStatusEx.ullAvailPhys;
+                _memoryStatus.TotalPageFile = _memoryStatusEx.ullTotalPageFile;
+                _memoryStatus.AvailablePageFile = _memoryStatusEx.ullAvailPageFile;
+                _memoryStatus.TotalVirtual = _memoryStatusEx.ullTotalVirtual;
+                _memoryStatus.AvailableVirtual = _memoryStatusEx.ullAvailVirtual;
+                _memoryStatus.AvailableExtendedVirtual = _memoryStatusEx.ullAvailExtendedVirtual;
+            }
+
+            return _memoryStatus;
+        }
+
+        public static T GetPropertyValue<T>(object obj) where T : struct
+        {
+            return (obj == null) ? default : (T)obj;
+        }
+
+        public static T[] GetPropertyArray<T>(object obj)
+        {
+            return (obj is T[] array) ? array : Array.Empty<T>();
+        }
+
+        public static string GetPropertyString(object obj)
+        {
+            return (obj is string str) ? str : string.Empty;
+        }
+
+        public static string GetStringFromUInt16Array(ushort[] array)
+        {
+            return Encoding.Unicode.GetString(MemoryMarshal.AsBytes(array.AsSpan()));
+        }
+        public static string GetStringFromUInt16Array(int[] array)
+        {
+            return Encoding.Unicode.GetString(MemoryMarshal.AsBytes(array.AsSpan()));
+        }
+
+        public List<Battery> GetBatteryList()
+        {
+            List<Battery> batteryList = new List<Battery>();
+
+            string queryString = UseAsteriskInWMI ? "SELECT * FROM Win32_Battery"
+                                                  : "SELECT FullChargeCapacity, DesignCapacity, BatteryStatus, EstimatedChargeRemaining, EstimatedRunTime, ExpectedLife, MaxRechargeTime, TimeOnBattery, TimeToFullCharge FROM Win32_Battery";
+            using ManagementObjectSearcher mos = new ManagementObjectSearcher(_managementScope, queryString, _timeout);
+
+            foreach (var mo in mos.Get())
+            {
+                Battery battery = new Battery
+                {
+                    FullChargeCapacity = mo.GetProperty<uint>("FullChargeCapacity"),
+                    DesignCapacity = mo.GetProperty<uint>("DesignCapacity"),
+                    BatteryStatus = (ushort) mo.GetProperty<int>("BatteryStatus"),
+                    EstimatedChargeRemaining = (ushort) mo.GetProperty<int>("EstimatedChargeRemaining"),
+                    EstimatedRunTime = mo.GetProperty<uint>("EstimatedRunTime"),
+                    ExpectedLife = mo.GetProperty<uint>("ExpectedLife"),
+                    MaxRechargeTime = mo.GetProperty<uint>("MaxRechargeTime"),
+                    TimeOnBattery = mo.GetProperty<uint>("TimeOnBattery"),
+                    TimeToFullCharge = mo.GetProperty<uint>("TimeToFullCharge")
+                };
+
+                batteryList.Add(battery);
+            }
+
+            return batteryList;
+        }
+
+        public List<BIOS> GetBiosList()
+        {
+            List<BIOS> biosList = new List<BIOS>();
+
+            string queryString = UseAsteriskInWMI ? "SELECT * FROM Win32_BIOS"
+                                                  : "SELECT Caption, Description, Manufacturer, Name, ReleaseDate, SerialNumber, SoftwareElementID, Version FROM Win32_BIOS";
+            using ManagementObjectSearcher mos = new ManagementObjectSearcher(_managementScope, queryString, _timeout);
+
+            foreach (var mo in mos.Get())
+            {
+                BIOS bios = new BIOS
+                {
+                    Caption = mo.GetProperty<string>("Caption"),
+                    Description = mo.GetProperty<string>("Description"),
+                    Manufacturer = mo.GetProperty<string>("Manufacturer"),
+                    Name = mo.GetProperty<string>("Name"),
+                    ReleaseDate = mo.GetProperty<string>("ReleaseDate"),
+                    SerialNumber = mo.GetProperty<string>("SerialNumber"),
+                    SoftwareElementID = mo.GetProperty<string>("SoftwareElementID"),
+                    Version = mo.GetProperty<string>("Version")
+                };
+
+                biosList.Add(bios);
+            }
+
+            return biosList;
+        }
+
+        public List<ComputerSystem> GetComputerSystemList()
+        {
+            List<ComputerSystem> computerSystemList = new List<ComputerSystem>();
+
+            string queryString = UseAsteriskInWMI ? "SELECT * FROM Win32_ComputerSystemProduct"
+                                                  : "SELECT Caption, Description, IdentifyingNumber, Name, SKUNumber, UUID, Vendor, Version FROM Win32_ComputerSystemProduct";
+            using ManagementObjectSearcher mos = new ManagementObjectSearcher(_managementScope, queryString, _timeout);
+
+            foreach (var mo in mos.Get())
+            {
+                ComputerSystem computerSystem = new ComputerSystem
+                {
+                    Caption = mo.GetProperty<string>("Caption"),
+                    Description = mo.GetProperty<string>("Description"),
+                    IdentifyingNumber = mo.GetProperty<string>("IdentifyingNumber"),
+                    Name = mo.GetProperty<string>("Name"),
+                    SKUNumber = mo.GetProperty<string>("SKUNumber"),
+                    UUID = mo.GetProperty<string>("UUID"),
+                    Vendor = mo.GetProperty<string>("Vendor"),
+                    Version = mo.GetProperty<string>("Version")
+                };
+
+                computerSystemList.Add(computerSystem);
+            }
+
+            return computerSystemList;
+        }
+
+        public List<CPU> GetCpuList(bool includePercentProcessorTime = true)
+        {
+            List<CPU> cpuList = new List<CPU>();
+
+            List<CpuCore> cpuCoreList = new List<CpuCore>();
+
+            ulong percentProcessorTime = 0ul;
+
+            if (includePercentProcessorTime)
+            {
+                string queryString = UseAsteriskInWMI ? "SELECT * FROM Win32_PerfFormattedData_PerfOS_Processor WHERE Name != '_Total'"
+                                                      : "SELECT Name, PercentProcessorTime FROM Win32_PerfFormattedData_PerfOS_Processor WHERE Name != '_Total'";
+                ManagementObjectSearcher percentProcessorTimeMOS = new ManagementObjectSearcher(_managementScope, queryString, _timeout);
+
+                queryString = UseAsteriskInWMI ? "SELECT * FROM Win32_PerfFormattedData_PerfOS_Processor WHERE Name = '_Total'"
+                                               : "SELECT PercentProcessorTime FROM Win32_PerfFormattedData_PerfOS_Processor WHERE Name = '_Total'";
+                ManagementObjectSearcher totalPercentProcessorTimeMOS = new ManagementObjectSearcher(_managementScope, queryString, _timeout);
+
+                try
+                {
+                    foreach (var mo in percentProcessorTimeMOS.Get())
+                    {
+                        CpuCore core = new CpuCore
+                        {
+                            Name = mo.GetProperty<string>("Name"),
+                            PercentProcessorTime = ulong.Parse(mo.GetProperty<string>("PercentProcessorTime", "0"))
+                        };
+
+                        cpuCoreList.Add(core);
+                    }
+
+                    foreach (var mo in totalPercentProcessorTimeMOS.Get())
+                    {
+                        percentProcessorTime = ulong.Parse(mo.GetProperty<string>("PercentProcessorTime", "0"));
+                    }
+                }
+                catch (ManagementException)
+                {
+                    // https://github.com/Jinjinov/Hardware.Info/issues/30
+                }
+                finally
+                {
+                    percentProcessorTimeMOS.Dispose();
+
+                    totalPercentProcessorTimeMOS.Dispose();
+                }
+
+                if (percentProcessorTime == 0ul)
+                {
+                    queryString = UseAsteriskInWMI ? "SELECT * FROM Win32_Processor"
+                                                   : "SELECT LoadPercentage FROM Win32_Processor";
+                    using ManagementObjectSearcher loadPercentageMOS = new ManagementObjectSearcher(_managementScope, queryString, _timeout);
+
+                    foreach (var mo in loadPercentageMOS.Get())
+                    {
+                        percentProcessorTime = (uint) mo.GetProperty<int>("LoadPercentage");
+                    }
+                }
+            }
+
+            bool isAtLeastWin8 = (_os.Version.Major == 6 && _os.Version.Minor >= 2) || (_os.Version.Major > 6);
+
+            string query = UseAsteriskInWMI ? "SELECT * FROM Win32_Processor"
+                                            : isAtLeastWin8 ? "SELECT Caption, CurrentClockSpeed, Description, L2CacheSize, L3CacheSize, Manufacturer, MaxClockSpeed, Name, NumberOfCores, NumberOfLogicalProcessors, ProcessorId, SecondLevelAddressTranslationExtensions, SocketDesignation, VirtualizationFirmwareEnabled, VMMonitorModeExtensions FROM Win32_Processor"
+                                                            : "SELECT Caption, CurrentClockSpeed, Description, L2CacheSize, L3CacheSize, Manufacturer, MaxClockSpeed, Name, NumberOfCores, NumberOfLogicalProcessors, ProcessorId, SocketDesignation FROM Win32_Processor";
+            using ManagementObjectSearcher mos = new ManagementObjectSearcher(_managementScope, query, _timeout);
+
+            float processorPerformance = 100f;
+
+            try
+            {
+                using PerformanceCounter cpuCounter = new PerformanceCounter("Processor Information", "% Processor Performance", "_Total");
+                processorPerformance = cpuCounter.NextValue();
+                System.Threading.Thread.Sleep(1); // the first call to NextValue() always returns 0
+                processorPerformance = cpuCounter.NextValue();
+            }
+            catch
+            {
+                // Ignore performance counter errors and just assume that it's at 100 %
+            }
+
+            uint L1InstructionCacheSize = 0;
+            uint L1DataCacheSize = 0;
+            // L1 = 3
+            // L2 = 4
+            // L3 = 5
+            query = UseAsteriskInWMI ? "SELECT * FROM Win32_CacheMemory WHERE Level = 3"
+                                     : "SELECT CacheType, MaxCacheSize FROM Win32_CacheMemory WHERE Level = 3";
+            using ManagementObjectSearcher Win32_CacheMemory = new ManagementObjectSearcher(_managementScope, query, _timeout);
+
+            // Other = 1
+            // Unknown = 2
+            // Instruction = 3
+            // Data = 4
+            // Unified = 5
+            foreach (var mo in Win32_CacheMemory.Get())
+            {
+                ushort CacheType = (ushort) mo.GetProperty<int>("CacheType");
+                uint MaxCacheSize = 1024 * mo.GetProperty<uint>("MaxCacheSize");
+
+                // if CacheType is Other or Unknown
+                if (L1InstructionCacheSize == 0)
+                    L1InstructionCacheSize = MaxCacheSize;
+
+                // if CacheType is Other or Unknown
+                if (L1DataCacheSize == 0)
+                    L1DataCacheSize = MaxCacheSize;
+
+                if (CacheType == 3) // Instruction
+                    L1InstructionCacheSize = MaxCacheSize;
+
+                if (CacheType == 4) // Data
+                    L1DataCacheSize = MaxCacheSize;
+            }
+
+            foreach (var mo in mos.Get())
+            {
+                uint maxClockSpeed = mo.GetProperty<uint>("MaxClockSpeed");
+
+                uint currentClockSpeed = (uint)(maxClockSpeed * (processorPerformance / 100));
+
+                CPU cpu = new CPU
+                {
+                    Caption = mo.GetProperty<string>("Caption"),
+                    //CurrentClockSpeed = GetPropertyValue<uint>(mo["CurrentClockSpeed"]), https://stackoverflow.com/questions/61802420/unable-to-get-current-cpu-frequency-in-powershell-or-python
+                    CurrentClockSpeed = currentClockSpeed,
+                    Description = mo.GetProperty<string>("Description"),
+                    L1InstructionCacheSize = L1InstructionCacheSize,
+                    L1DataCacheSize = L1DataCacheSize,
+                    L2CacheSize = 1024 * mo.GetProperty<uint>("L2CacheSize"),
+                    L3CacheSize = 1024 * mo.GetProperty<uint>("L3CacheSize"),
+                    Manufacturer = mo.GetProperty<string>("Manufacturer"),
+                    MaxClockSpeed = maxClockSpeed,
+                    Name = mo.GetProperty<string>("Name"),
+                    NumberOfCores = mo.GetProperty<uint>("NumberOfCores"),
+                    NumberOfLogicalProcessors = mo.GetProperty<uint>("NumberOfLogicalProcessors"),
+                    ProcessorId = mo.GetProperty<string>("ProcessorId"),
+                    SocketDesignation = mo.GetProperty<string>("SocketDesignation"),
+                    PercentProcessorTime = percentProcessorTime,
+                    CpuCoreList = cpuCoreList
+                };
+
+                if (isAtLeastWin8)
+                {
+                    cpu.SecondLevelAddressTranslationExtensions = mo.GetProperty<bool>("SecondLevelAddressTranslationExtensions");
+                    cpu.VirtualizationFirmwareEnabled = mo.GetProperty<bool>("VirtualizationFirmwareEnabled");
+                    cpu.VMMonitorModeExtensions = mo.GetProperty<bool>("VMMonitorModeExtensions");
+                }
+
+                cpuList.Add(cpu);
+            }
+
+            return cpuList;
+        }
+
+        public override List<Drive> GetDriveList()
+        {
+            List<Drive> driveList = new List<Drive>();
+
+            string queryString = UseAsteriskInWMI ? "SELECT * FROM Win32_DiskDrive"
+                                                  : "SELECT Caption, Description, DeviceID, FirmwareRevision, Index, Manufacturer, Model, Name, Partitions, SerialNumber, Size FROM Win32_DiskDrive";
+            using ManagementObjectSearcher Win32_DiskDrive = new ManagementObjectSearcher(_managementScope, queryString, _timeout);
+
+            foreach (var DiskDrive in Win32_DiskDrive.Get())
+            {
+                Drive drive = new Drive
+                {
+                    Caption = DiskDrive.GetProperty<string>("Caption"),
+                    Description = DiskDrive.GetProperty<string>("Description"),
+                    FirmwareRevision = DiskDrive.GetProperty<string>("FirmwareRevision"),
+                    Index = DiskDrive.GetProperty<uint>("Index"),
+                    Manufacturer = DiskDrive.GetProperty<string>("Manufacturer"),
+                    Model = DiskDrive.GetProperty<string>("Model"),
+                    Name = DiskDrive.GetProperty<string>("Name"),
+                    Partitions = DiskDrive.GetProperty<uint>("Partitions"),
+                    SerialNumber = DiskDrive.GetProperty<string>("SerialNumber"),
+                    Size = ulong.Parse(DiskDrive.GetProperty<string>("Size", "0"))
+                };
+
+                string deviceId = DiskDrive.GetProperty<string>("DeviceID");
+                string queryString1 = "ASSOCIATORS OF {Win32_DiskDrive.DeviceID='" + deviceId + "'} WHERE AssocClass = Win32_DiskDriveToDiskPartition";
+                using ManagementObjectSearcher Win32_DiskPartition = new ManagementObjectSearcher(_managementScope, queryString1, _timeout);
+
+                foreach (var DiskPartition in Win32_DiskPartition.Get())
+                {
+                    Partition partition = new Partition
+                    {
+                        Bootable = DiskPartition.GetProperty<bool>("Bootable"),
+                        BootPartition = DiskPartition.GetProperty<bool>("BootPartition"),
+                        Caption = DiskPartition.GetProperty<string>("Caption"),
+                        Description = DiskPartition.GetProperty<string>("Description"),
+                        DiskIndex = DiskPartition.GetProperty<uint>("DiskIndex"),
+                        Index = DiskPartition.GetProperty<uint>("Index"),
+                        Name = DiskPartition.GetProperty<string>("Name"),
+                        PrimaryPartition = DiskPartition.GetProperty<bool>("PrimaryPartition"),
+                        Size = ulong.CreateTruncating(UInt128.Parse(DiskPartition.GetProperty<string>("Size", "0"))),
+                        StartingOffset = ulong.Parse(DiskPartition.GetProperty<string>("StartingOffset"))
+                    };
+
+                    var partitionDeviceId = DiskPartition.GetProperty<string>("DeviceID");
+                    string queryString2 = "ASSOCIATORS OF {Win32_DiskPartition.DeviceID='" + partitionDeviceId + "'} WHERE AssocClass = Win32_LogicalDiskToPartition";
+                    using ManagementObjectSearcher Win32_LogicalDisk = new ManagementObjectSearcher(_managementScope, queryString2, _timeout);
+
+                    foreach (var LogicalDisk in Win32_LogicalDisk.Get())
+                    {
+                        Volume volume = new Volume
+                        {
+                            Caption = LogicalDisk.GetProperty<string>("Caption"),
+                            Compressed = LogicalDisk.GetProperty<bool>("Compressed"),
+                            Description = LogicalDisk.GetProperty<string>("Description"),
+                            FileSystem = LogicalDisk.GetProperty<string>("FileSystem"),
+                            FreeSpace = ulong.CreateTruncating(ulong.Parse(LogicalDisk.GetProperty<string>("FreeSpace"))),
+                            Name = LogicalDisk.GetProperty<string>("Name"),
+                            Size = ulong.CreateTruncating(ulong.Parse(LogicalDisk.GetProperty<string>("Size"))),
+                            VolumeName = LogicalDisk.GetProperty<string>("VolumeName"),
+                            VolumeSerialNumber = LogicalDisk.GetProperty<string>("VolumeSerialNumber")
+                        };
+
+                        partition.VolumeList.Add(volume);
+                    }
+
+                    drive.PartitionList.Add(partition);
+                }
+
+                driveList.Add(drive);
+            }
+
+            return driveList;
+        }
+
+        public List<Keyboard> GetKeyboardList()
+        {
+            List<Keyboard> keyboardList = new List<Keyboard>();
+
+            string queryString = UseAsteriskInWMI ? "SELECT * FROM Win32_Keyboard"
+                                                  : "SELECT Caption, Description, Name, NumberOfFunctionKeys FROM Win32_Keyboard";
+            using ManagementObjectSearcher mos = new ManagementObjectSearcher(_managementScope, queryString, _timeout);
+
+            foreach (var mo in mos.Get())
+            {
+                Keyboard keyboard = new Keyboard
+                {
+                    Caption = mo.GetProperty<string>("Caption"),
+                    Description = mo.GetProperty<string>("Description"),
+                    Name = mo.GetProperty<string>("Name"),
+                    NumberOfFunctionKeys = (ushort) mo.GetProperty<int>("NumberOfFunctionKeys")
+                };
+
+                keyboardList.Add(keyboard);
+            }
+
+            return keyboardList;
+        }
+
+        public List<Memory> GetMemoryList()
+        {
+            List<Memory> memoryList = new List<Memory>();
+
+            string queryString = UseAsteriskInWMI ? "SELECT * FROM Win32_PhysicalMemory"
+                                                  : _os.Version.Major >= 10 ? "SELECT BankLabel, Capacity, FormFactor, Manufacturer, MaxVoltage, MinVoltage, PartNumber, SerialNumber, Speed FROM Win32_PhysicalMemory"
+                                                                            : "SELECT BankLabel, Capacity, FormFactor, Manufacturer, PartNumber, SerialNumber, Speed FROM Win32_PhysicalMemory";
+            using ManagementObjectSearcher mos = new ManagementObjectSearcher(_managementScope, queryString, _timeout);
+
+            foreach (var mo in mos.Get())
+            {
+                Memory memory = new Memory
+                {
+                    BankLabel = mo.GetProperty<string>("BankLabel"),
+                    Capacity = ulong.Parse(mo.GetProperty<string>("Capacity")),
+                    FormFactor = (FormFactor)mo.GetProperty<int>("FormFactor"),
+                    Manufacturer = mo.GetProperty<string>("Manufacturer"),
+                    PartNumber = mo.GetProperty<string>("PartNumber"),
+                    SerialNumber = mo.GetProperty<string>("SerialNumber"),
+                                Speed = mo.GetProperty<uint>("Speed")
+                };
+
+                if (_os.Version.Major >= 10)
+                {
+                    memory.MaxVoltage = mo.GetProperty<uint>("MaxVoltage");
+                    memory.MinVoltage = mo.GetProperty<uint>("MinVoltage");
+                }
+
+                memoryList.Add(memory);
+            }
+
+            return memoryList;
+        }
+
+        public List<Monitor> GetMonitorList()
+        {
+            List<Monitor> monitorList = new List<Monitor>();
+
+            string win32PnpEntityQuery = UseAsteriskInWMI ? "SELECT * FROM Win32_PnPEntity WHERE PNPClass='Monitor'"
+                                                          : "SELECT DeviceId FROM Win32_PnPEntity WHERE PNPClass='Monitor'";
+            using ManagementObjectSearcher win32PnpEntityMos = new ManagementObjectSearcher(_managementScope, win32PnpEntityQuery, _timeout);
+
+            foreach (var win32PnpEntityMo in win32PnpEntityMos.Get())
+            {
+                string deviceId = win32PnpEntityMo.GetProperty<string>("DeviceId");
+                string win32DesktopMonitorQuery = UseAsteriskInWMI ? $"SELECT * FROM Win32_DesktopMonitor WHERE PNPDeviceId='{deviceId}'"
+                                                                   : $"SELECT Caption, Description, MonitorManufacturer, MonitorType, Name, PixelsPerXLogicalInch, PixelsPerYLogicalInch FROM Win32_DesktopMonitor WHERE PNPDeviceId='{deviceId}'";
+                using ManagementObjectSearcher win32DesktopMonitorMos = new ManagementObjectSearcher(_managementScope, win32DesktopMonitorQuery.Replace(@"\", @"\\"), _timeout);
+                
+                string wmiMonitorIdQuery = UseAsteriskInWMI ? $"SELECT * FROM WmiMonitorID WHERE InstanceName LIKE '{deviceId}%'"
+                                                            : $"SELECT Active, ProductCodeID, SerialNumberID, ManufacturerName, UserFriendlyName, WeekOfManufacture, YearOfManufacture FROM WmiMonitorID WHERE InstanceName LIKE '{deviceId}%'";
+                using ManagementObjectSearcher wmiMonitorIdMos = new ManagementObjectSearcher(_managementScopeWmi, wmiMonitorIdQuery.Replace(@"\", "_"), _timeout);
+
+                Monitor monitor = new Monitor();
+
+                foreach (var desktopMonitorMo in win32DesktopMonitorMos.Get())
+                {
+                    monitor.Caption = desktopMonitorMo.GetProperty<string>("Caption");
+                    monitor.Description = desktopMonitorMo.GetProperty<string>("Description");
+                    monitor.MonitorManufacturer = desktopMonitorMo.GetProperty<string>("MonitorManufacturer");
+                    monitor.MonitorType = desktopMonitorMo.GetProperty<string>("MonitorType");
+                    monitor.Name = desktopMonitorMo.GetProperty<string>("Name");
+                    monitor.PixelsPerXLogicalInch = desktopMonitorMo.GetProperty<uint>("PixelsPerXLogicalInch");
+                    monitor.PixelsPerYLogicalInch = desktopMonitorMo.GetProperty<uint>("PixelsPerYLogicalInch");
+
+                    break;
+                }
+
+                foreach (var wmiMonitorIdMo in wmiMonitorIdMos.Get())
+                {
+                    monitor.Active = wmiMonitorIdMo.GetProperty<bool>("Active");
+                    monitor.ProductCodeID = GetStringFromUInt16Array(wmiMonitorIdMo.GetArrayProperty<int>("ProductCodeID"));
+                    monitor.UserFriendlyName = GetStringFromUInt16Array(wmiMonitorIdMo.GetArrayProperty<ushort>("UserFriendlyName"));
+                    monitor.SerialNumberID = GetStringFromUInt16Array(wmiMonitorIdMo.GetArrayProperty<int>("SerialNumberID"));
+                    monitor.ManufacturerName = GetStringFromUInt16Array(wmiMonitorIdMo.GetArrayProperty<int>("ManufacturerName"));
+                    monitor.WeekOfManufacture = (ushort) wmiMonitorIdMo.GetProperty<byte>("WeekOfManufacture");
+                    monitor.YearOfManufacture = (ushort) wmiMonitorIdMo.GetProperty<int>("YearOfManufacture");
+
+                    break;
+                }
+
+                monitorList.Add(monitor);
+            }
+
+            return monitorList;
+        }
+
+        public List<Motherboard> GetMotherboardList()
+        {
+            List<Motherboard> motherboardList = new List<Motherboard>();
+
+            string queryString = UseAsteriskInWMI ? "SELECT * FROM Win32_BaseBoard"
+                                                  : "SELECT Manufacturer, Product, SerialNumber FROM Win32_BaseBoard";
+            using ManagementObjectSearcher mos = new ManagementObjectSearcher(_managementScope, queryString, _timeout);
+
+            foreach (var mo in mos.Get())
+            {
+                Motherboard motherboard = new Motherboard
+                {
+                    Manufacturer = mo.GetProperty<string>("Manufacturer"),
+                    Product = mo.GetProperty<string>("Product"),
+                    SerialNumber = mo.GetProperty<string>("SerialNumber")
+                };
+
+                motherboardList.Add(motherboard);
+            }
+
+            return motherboardList;
+        }
+
+        public List<Mouse> GetMouseList()
+        {
+            List<Mouse> mouseList = new List<Mouse>();
+
+            string queryString = UseAsteriskInWMI ? "SELECT * FROM Win32_PointingDevice"
+                                                  : "SELECT Caption, Description, Manufacturer, Name, NumberOfButtons FROM Win32_PointingDevice";
+            using ManagementObjectSearcher mos = new ManagementObjectSearcher(_managementScope, queryString, _timeout);
+
+            foreach (var mo in mos.Get())
+            {
+                Mouse mouse = new Mouse
+                {
+                    Caption = mo.GetProperty<string>("Caption"),
+                    Description = mo.GetProperty<string>("Description"),
+                    Manufacturer = mo.GetProperty<string>("Manufacturer"),
+                    Name = mo.GetProperty<string>("Name"),
+                    NumberOfButtons = mo.GetProperty<byte>("NumberOfButtons")
+                };
+
+                mouseList.Add(mouse);
+            }
+
+            return mouseList;
+        }
+
+        public override List<NetworkAdapter> GetNetworkAdapterList(bool includeBytesPersec = true, bool includeNetworkAdapterConfiguration = true)
+        {
+            List<NetworkAdapter> networkAdapterList = new List<NetworkAdapter>();
+
+            string queryString = UseAsteriskInWMI ? "SELECT * FROM Win32_NetworkAdapter WHERE PhysicalAdapter=True AND MACAddress IS NOT NULL"
+                                                  : "SELECT AdapterType, Caption, Description, DeviceID, MACAddress, Manufacturer, Name, NetConnectionID, ProductName, Speed FROM Win32_NetworkAdapter WHERE PhysicalAdapter=True AND MACAddress IS NOT NULL";
+            using ManagementObjectSearcher mos = new ManagementObjectSearcher(_managementScope, queryString, _timeout);
+
+            foreach (var mo in mos.Get())
+            {
+                NetworkAdapter networkAdapter = new NetworkAdapter
+                {
+                    AdapterType = mo.GetProperty<string>("AdapterType"),
+                    Caption = mo.GetProperty<string>("Caption"),
+                    Description = mo.GetProperty<string>("Description"),
+                    MACAddress = mo.GetProperty<string>("MACAddress"),
+                    Manufacturer = mo.GetProperty<string>("Manufacturer"),
+                    Name = mo.GetProperty<string>("Name"),
+                    NetConnectionID = mo.GetProperty<string>("NetConnectionID"),
+                    ProductName = mo.GetProperty<string>("ProductName"),
+                    Speed = ulong.Parse(mo.GetProperty<string>("Speed"))
+                };
+
+                if (includeBytesPersec)
+                {
+                    // https://learn.microsoft.com/en-us/dotnet/api/system.diagnostics.performancecounter.instancename
+
+                    string name = networkAdapter.Name.Replace('(', '[').Replace(')', ']').Replace('#', '_').Replace('\\', '_').Replace('/', '_');
+
+                    string query = UseAsteriskInWMI ? $"SELECT * FROM Win32_PerfFormattedData_Tcpip_NetworkAdapter WHERE Name = '{name}'"
+                                                    : $"SELECT BytesSentPersec, BytesReceivedPersec, CurrentBandwidth FROM Win32_PerfFormattedData_Tcpip_NetworkAdapter WHERE Name = '{name}'";
+                    using ManagementObjectSearcher managementObjectSearcher = new ManagementObjectSearcher(_managementScope, query, _timeout);
+
+                    foreach (var managementObject in managementObjectSearcher.Get())
+                    {
+                        networkAdapter.BytesSentPersec = ulong.Parse(managementObject.GetProperty<string>("BytesSentPersec"));
+                        networkAdapter.BytesReceivedPersec = ulong.Parse(managementObject.GetProperty<string>("BytesReceivedPersec"));
+
+                        if (networkAdapter.Speed == 0 || networkAdapter.Speed == long.MaxValue)
+                        {
+                            networkAdapter.Speed = managementObject.GetProperty<ulong>("CurrentBandwidth");
+                        }
+                    }
+                }
+
+                if (includeNetworkAdapterConfiguration)
+                {
+                    IPAddress address;
+
+                    string query = $"ASSOCIATORS OF {{{mo.GetProperty<string>("__RelPath")}}} where resultclass = Win32_NetworkAdapterConfiguration";
+
+                    using ManagementObjectSearcher managementObjectSearcher = new ManagementObjectSearcher(_managementScope, query, _timeout);
+
+
+                    foreach (var configuration in managementObjectSearcher.Get())
+                    {
+                        foreach (string str in configuration.GetArrayProperty<string>("DefaultIPGateway"))
+                            if (IPAddress.TryParse(str, out address))
+                                networkAdapter.DefaultIPGatewayList.Add(address);
+
+                        if (IPAddress.TryParse(configuration.GetProperty<string>("DHCPServer"), out address))
+                            networkAdapter.DHCPServer = address;
+
+                        foreach (string str in configuration.GetArrayProperty<string>("DNSServerSearchOrder"))
+                            if (IPAddress.TryParse(str, out address))
+                                networkAdapter.DNSServerSearchOrderList.Add(address);
+
+                        foreach (string str in configuration.GetArrayProperty<string>("IPAddress"))
+                            if (IPAddress.TryParse(str, out address))
+                                networkAdapter.IPAddressList.Add(address);
+
+                        foreach (string str in configuration.GetArrayProperty<string>("IPSubnet"))
+                            if (IPAddress.TryParse(str, out address))
+                                networkAdapter.IPSubnetList.Add(address);
+                    }
+                }
+
+                networkAdapterList.Add(networkAdapter);
+            }
+
+            return networkAdapterList;
+        }
+
+        public List<Printer> GetPrinterList()
+        {
+            List<Printer> printerList = new List<Printer>();
+
+            string queryString = UseAsteriskInWMI ? "SELECT * FROM Win32_Printer"
+                                                  : "SELECT Caption, Default, Description, HorizontalResolution, Local, Name, Network, Shared, VerticalResolution FROM Win32_Printer";
+            using ManagementObjectSearcher mos = new ManagementObjectSearcher(_managementScope, queryString, _timeout);
+
+            foreach (var mo in mos.Get())
+            {
+                Printer printer = new Printer
+                {
+                    Caption = mo.GetProperty<string>("Caption"),
+                    Default = mo.GetProperty<bool>("Default"),
+                    Description = mo.GetProperty<string>("Description"),
+                    HorizontalResolution = mo.GetProperty<uint>("HorizontalResolution"),
+                    Local = mo.GetProperty<bool>("Local"),
+                    Name = mo.GetProperty<string>("Name"),
+                    Network = mo.GetProperty<bool>("Network"),
+                    Shared = mo.GetProperty<bool>("Shared"),
+                    VerticalResolution = mo.GetProperty<uint>("VerticalResolution")            };
+
+                printerList.Add(printer);
+            }
+
+            return printerList;
+        }
+
+        public List<SoundDevice> GetSoundDeviceList()
+        {
+            List<SoundDevice> soundDeviceList = new List<SoundDevice>();
+
+            string queryString = UseAsteriskInWMI ? "SELECT * FROM Win32_SoundDevice WHERE NOT Manufacturer='Microsoft'"
+                                                  : "SELECT Caption, Description, Manufacturer, Name, ProductName FROM Win32_SoundDevice WHERE NOT Manufacturer='Microsoft'";
+            using ManagementObjectSearcher mos = new ManagementObjectSearcher(_managementScope, queryString, _timeout);
+
+            foreach (var mo in mos.Get())
+            {
+                SoundDevice soundDevice = new SoundDevice
+                {
+                    Caption = mo.GetProperty<string>("Caption"),
+                    Description = mo.GetProperty<string>("Description"),
+                    Manufacturer = mo.GetProperty<string>("Manufacturer"),
+                    Name = mo.GetProperty<string>("Name"),
+                    ProductName = mo.GetProperty<string>("ProductName")
+                };
+
+                soundDeviceList.Add(soundDevice);
+            }
+
+            return soundDeviceList;
+        }
+
+        public List<VideoController> GetVideoControllerList()
+        {
+            List<VideoController> videoControllerList = new List<VideoController>();
+
+            string queryString = UseAsteriskInWMI ? "SELECT * FROM Win32_VideoController"
+                                                  : "SELECT AdapterCompatibility, AdapterRAM, Caption, CurrentBitsPerPixel, CurrentHorizontalResolution, CurrentNumberOfColors, CurrentRefreshRate, CurrentVerticalResolution, Description, DriverDate, DriverVersion, MaxRefreshRate, MinRefreshRate, Name, PNPDeviceID, VideoModeDescription, VideoProcessor FROM Win32_VideoController";
+            using ManagementObjectSearcher mos = new ManagementObjectSearcher(_managementScope, queryString, _timeout);
+
+            foreach (var mo in mos.Get())
+            {
+                VideoController videoController = new VideoController
+                {
+                    Manufacturer = mo.GetProperty<string>("AdapterCompatibility"),
+                    AdapterRAM = mo.GetProperty<uint>("AdapterRAM"),
+                    Caption = mo.GetProperty<string>("Caption"),
+                    CurrentBitsPerPixel = mo.GetProperty<uint>("CurrentBitsPerPixel"),
+                    CurrentHorizontalResolution = mo.GetProperty<uint>("CurrentHorizontalResolution"),
+                    CurrentNumberOfColors = UInt64.Parse(mo.GetProperty<string>("CurrentNumberOfColors")),
+                    CurrentRefreshRate = mo.GetProperty<uint>("CurrentRefreshRate"),
+                    CurrentVerticalResolution = mo.GetProperty<uint>("CurrentVerticalResolution"),
+                    Description = mo.GetProperty<string>("Description"),
+                    DriverDate = mo.GetProperty<string>("DriverDate"),
+                    DriverVersion = mo.GetProperty<string>("DriverVersion"),
+                    MaxRefreshRate = mo.GetProperty<uint>("MaxRefreshRate"),
+                    MinRefreshRate = mo.GetProperty<uint>("MinRefreshRate"),
+                    Name = mo.GetProperty<string>("Name"),
+                    VideoModeDescription = mo.GetProperty<string>("VideoModeDescription"),
+                    VideoProcessor = mo.GetProperty<string>("VideoProcessor")
+                };
+
+                try
+                {
+                    string deviceID = mo.GetProperty<string>("PNPDeviceID");
+
+                    if (string.IsNullOrEmpty(deviceID))
+                        continue;
+
+                    object? driverObject = Microsoft.Win32.Registry.GetValue(@$"HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Enum\{deviceID}", "Driver", default(string));
+
+                    if (driverObject is string driver && !string.IsNullOrEmpty(driver))
+                    {
+                        object? qwMemorySizeObject = Microsoft.Win32.Registry.GetValue(@$"HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Class\{driver}", "HardwareInformation.qwMemorySize", default(long));
+
+                        if (qwMemorySizeObject is long qwMemorySize && qwMemorySize != 0L)
+                        {
+                            videoController.AdapterRAM = (ulong)qwMemorySize;
+                        }
+                    }
+                }
+                catch (SecurityException)
+                {
+                }
+                catch (UnauthorizedAccessException)
+                {
+                }
+
+                videoControllerList.Add(videoController);
+            }
+
+            return videoControllerList;
+        }
+    }
+}

--- a/Hardware.Info.Windows.Aot/ManagementObjectSearcher.cs
+++ b/Hardware.Info.Windows.Aot/ManagementObjectSearcher.cs
@@ -1,0 +1,432 @@
+﻿using System;
+using System.Buffers;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
+using System.Text;
+using System.Threading.Tasks;
+using Windows.Win32;
+using Windows.Win32.Foundation;
+using Windows.Win32.System.Com;
+using Windows.Win32.System.Variant;
+using Windows.Win32.System.Wmi;
+using Hardware.Info.Windows.Aot;
+
+using static Hardware.Info.Windows.Aot.Constants;
+using static Windows.Win32.System_Wmi_IWbemClassObject_Extensions;
+using System.Xml.Linq;
+
+namespace Hardware.Info.Windows.Aot
+{
+    delegate HRESULT ExtractValueDelegate<T>(in VARIANT variant, out T value);
+    delegate HRESULT ExtractArrayValueDelegate<T>(in VARIANT variant, Span<T> value, out uint length);
+
+
+    class ManagementObjectSearcher : IDisposable
+    {
+        private readonly int _timeout;
+        private SafeHandle _managementScope;
+        private SafeHandle _queryString;
+        private readonly SafeHandle _strQueryLanguage;
+
+        public ManagementObjectSearcher(string managementScope, string queryString, int timeout)
+        {
+            _timeout = timeout;
+
+            _managementScope = PInvoke.SysAllocString(managementScope);
+            _queryString = PInvoke.SysAllocString(queryString);
+
+            _strQueryLanguage = PInvoke.SysAllocString("WQL");
+        }
+
+        public unsafe WmiSearch Get()
+        {
+            // Obtain the initial locator to WMI
+            IWbemLocator* pLoc;
+            var hr = PInvoke.CoCreateInstance(
+                CLSID_WbemLocator,
+                (IUnknown*)0,
+                CLSCTX.CLSCTX_INPROC_SERVER,
+                out pLoc
+            );
+
+            if (hr.Failed)
+            {
+                PInvoke.CoUninitialize();
+                hr.ThrowOnFailure();
+                return WmiSearch.Null;
+            }
+
+            // Connect to WMI through the IWbemLocator::ConnectServer method
+            IWbemServices* pSvc;
+
+            hr = pLoc->ConnectServer(
+                _managementScope,
+                new SysFreeStringSafeHandle(0), // User name
+                new SysFreeStringSafeHandle(0), // Password
+                new SysFreeStringSafeHandle(0), // Locale
+                0, // Security flags
+                new SysFreeStringSafeHandle(0), // Authority
+                (IWbemContext*)0, // Context
+                &pSvc // IWbemServices proxy
+            );
+
+            if (hr.Failed)
+            {
+                pLoc->Release();
+                PInvoke.CoUninitialize();
+                return WmiSearch.Null;
+            }
+
+            // Set security levels on the proxy
+            hr = PInvoke.CoSetProxyBlanket(
+                (IUnknown*)pSvc,
+                RPC_C_AUTHN_WINNT,
+                RPC_C_AUTHZ_NONE,
+                new PWSTR((char*)0),
+                RPC_C_AUTHN_LEVEL.RPC_C_AUTHN_LEVEL_CALL,
+                RPC_C_IMP_LEVEL.RPC_C_IMP_LEVEL_IMPERSONATE,
+                (void*)0,
+                EOLE_AUTHENTICATION_CAPABILITIES.EOAC_NONE
+            );
+
+            if (hr.Failed)
+            {
+                Console.WriteLine($"Could not set proxy blanket. Error code = 0x{hr:X}");
+                pSvc->Release();
+                pLoc->Release();
+                PInvoke.CoUninitialize();
+                return WmiSearch.Null;
+            }
+
+            // Perform WMI query to get the Win32_OperatingSystem class
+
+            IEnumWbemClassObject* pEnumerator;
+            hr = pSvc->ExecQuery(
+                _strQueryLanguage,
+                _queryString,
+                WBEM_GENERIC_FLAG_TYPE.WBEM_FLAG_FORWARD_ONLY | WBEM_GENERIC_FLAG_TYPE.WBEM_RETURN_IMMEDIATELY,
+                (IWbemContext*)0,
+                &pEnumerator
+            );
+
+            if (hr.Failed)
+            {
+                Console.WriteLine($"WMI query failed. Error code = 0x{hr:X}");
+                pSvc->Release();
+                pLoc->Release();
+                PInvoke.CoUninitialize();
+                return WmiSearch.Null;
+            }
+
+            return new WmiSearch(
+                pSvc, pLoc, pEnumerator, _timeout);
+        }
+
+        public void Close()
+        {
+            PInvoke.CoUninitialize();
+        }
+
+
+        private void ReleaseUnmanagedResources()
+        {
+            _managementScope.Dispose();
+             _queryString.Dispose();
+        }
+
+        private void Dispose(bool disposing)
+        {
+            ReleaseUnmanagedResources();
+            if (disposing)
+            {
+
+            }
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        ~ManagementObjectSearcher()
+        {
+            Dispose(false);
+        }
+    }
+
+    public unsafe ref struct WmiSearchResultItem
+    {
+        private readonly IWbemClassObject* _item;
+
+        internal WmiSearchResultItem(IWbemClassObject* item)
+        {
+            _item = item;
+        }
+
+        public unsafe T GetProperty<T>(string name, T defaultValue = default!)
+        {
+            VARIANT vtProp = new VARIANT();
+
+            var hr = _item->Get(name, 0, ref vtProp, (int*)0, (int*)0);
+
+            if (hr.Value == WBEM_E_NOT_FOUND || vtProp.Anonymous.Anonymous.vt == VARENUM.VT_NULL)
+            {
+                if (typeof(T) == typeof(string))
+                {
+                    return defaultValue ?? (T)(object)string.Empty;
+                }
+
+                return defaultValue;
+            }
+
+            hr.ThrowOnFailure();
+
+            if ((vtProp.Anonymous.Anonymous.vt & VARENUM.VT_ARRAY) == VARENUM.VT_ARRAY)
+            {
+                throw new InvalidOperationException(
+                    $"Property {name} is an array of values.");
+            }
+
+            if (typeof(T) == typeof(string))
+            {
+                if (vtProp.Anonymous.Anonymous.vt != VARENUM.VT_BSTR)
+                {
+                    throw new InvalidOperationException(
+                        $"Property {name} is of type {vtProp.Anonymous.Anonymous.vt} and not BSTR.");
+                }
+
+                var strValue = vtProp.Anonymous.Anonymous.Anonymous.bstrVal.AsSpan().ToString();
+
+                PInvoke.VariantClear(ref vtProp);
+
+                return (T)(object)strValue;
+            }
+
+            if (typeof(T) == typeof(ushort))
+            {
+                return (T)(object)this.ExtractValue<ushort>(name, ref vtProp, VARENUM.VT_UI2, PInvoke.VariantToUInt16);
+            }
+
+            if (typeof(T) == typeof(uint))
+            {
+                return (T)(object)this.ExtractValue<uint>(name, ref vtProp, VARENUM.VT_I4, PInvoke.VariantToUInt32);
+            }
+
+            if (typeof(T) == typeof(int))
+            {
+                return (T)(object)this.ExtractValue<int>(name, ref vtProp, VARENUM.VT_I4, PInvoke.VariantToInt32);
+            }
+
+            if (typeof(T) == typeof(UInt64))
+            {
+                return (T)(object)this.ExtractValue<UInt64>(name, ref vtProp, VARENUM.VT_UI8, PInvoke.VariantToUInt64);
+            }
+
+            if (typeof(T) == typeof(byte))
+            {
+                return (T)(object)this.ExtractValue<byte>(name, ref vtProp, VARENUM.VT_UI1,
+                    (in VARIANT v, out byte value) =>
+                    {
+                        value = v.Anonymous.Anonymous.Anonymous.bVal;
+                        return new HRESULT(0);
+                    });
+            }
+
+            if (typeof(T) == typeof(bool))
+            {
+                var boolValue = this.ExtractValue<BOOL>(name, ref vtProp, VARENUM.VT_BOOL, PInvoke.VariantToBoolean);
+
+                return defaultValue;
+            }
+
+            throw new NotSupportedException($"Type {typeof(T).FullName} is not supported.");
+        }
+
+        private T ExtractValue<T>(string propertyName, ref VARIANT variant, VARENUM expectedType, ExtractValueDelegate<T> extractFunc) where T:struct
+        {
+            if (variant.Anonymous.Anonymous.vt != expectedType)
+            {
+                throw new InvalidOperationException(
+                    $"Property {propertyName} is of type {variant.Anonymous.Anonymous.vt} and not {typeof(T).FullName}.");
+            }
+
+            T value;
+            extractFunc(in variant, out value);
+
+            PInvoke.VariantClear(ref variant);
+
+            return (T)value;
+        }
+
+        private T[] ExtractArrayValue<T>(string propertyName, ref VARIANT variant, VARENUM expectedType, ExtractArrayValueDelegate<T> extractFunc) where T : unmanaged
+        {
+            if ((variant.Anonymous.Anonymous.vt & expectedType) != expectedType)
+            {
+                throw new InvalidOperationException(
+                    $"Property {propertyName} is of type {variant.Anonymous.Anonymous.vt} and not {typeof(T).FullName}.");
+            }
+
+            Span<T> array = stackalloc T[10];
+            extractFunc(in variant, array, out uint length);
+
+            PInvoke.VariantClear(ref variant);
+
+            return array.Slice(0, (int)length).ToArray();
+        }
+
+        public unsafe T[] GetArrayProperty<T>(string name)
+        {
+            VARIANT vtProp = new VARIANT();
+            var hr = _item->Get(name, 0, ref vtProp, (int*)0, (int*)0);
+            hr.ThrowOnFailure();
+
+            if (vtProp.Anonymous.Anonymous.vt == VARENUM.VT_NULL)
+            {
+                return Array.Empty<T>();
+            }
+
+            if ((vtProp.Anonymous.Anonymous.vt & VARENUM.VT_ARRAY) != VARENUM.VT_ARRAY)
+            {
+                throw new InvalidOperationException(
+                    $"Property {name} is not an array of values.");
+            }
+
+            if (typeof(T) == typeof(string))
+            {
+                if ((vtProp.Anonymous.Anonymous.vt & VARENUM.VT_BSTR) != VARENUM.VT_BSTR)
+                {
+                    throw new InvalidOperationException(
+                        $"Property {name} is of type {vtProp.Anonymous.Anonymous.vt} and not bstr.");
+                }
+
+                const uint BUFFER_SIZE = 10;
+                Span<PWSTR> buffer = stackalloc PWSTR[(int)BUFFER_SIZE];
+
+                uint usedBufferLength;
+
+                hr = PInvoke.VariantToStringArray(in vtProp, buffer, out usedBufferLength);
+
+                hr.ThrowOnFailure();
+
+                var usedArray = buffer.Slice(0, (int)usedBufferLength);
+                var strArray = new string[usedArray.Length];
+                for (var i = 0; i < usedArray.Length; i++)
+                {
+                    strArray[i] = usedArray[i].AsSpan().ToString();
+                }
+
+                return (T[])(object)strArray;
+            }
+
+            if (typeof(T) == typeof(ushort))
+            {
+                return (T[]) (object) this.ExtractArrayValue<ushort>(name, ref vtProp, VARENUM.VT_UI2, PInvoke.VariantToUInt16Array);
+            }
+
+            if (typeof(T) == typeof(int))
+            {
+                return (T[])(object)this.ExtractArrayValue<int>(name, ref vtProp, VARENUM.VT_I4, PInvoke.VariantToInt32Array);
+            }
+
+            throw new NotSupportedException($"Type {typeof(T).FullName} is not supported.");
+        }
+    }
+
+    public unsafe ref struct WmiSearchResultsEnumerator
+    {
+        private Memory<IntPtr> _currentArray;
+        private MemoryHandle _currentArrayHandle;
+        private bool _isCurrentInUse;
+        private IEnumWbemClassObject* _enumerator;
+        private readonly int _timeout;
+
+
+        internal WmiSearchResultsEnumerator(IEnumWbemClassObject* enumerator, int timeout)
+        {
+            _enumerator = enumerator;
+            _timeout = timeout;
+            _currentArray = new IntPtr[1];
+            _currentArrayHandle = _currentArray.Pin();
+            _isCurrentInUse = false;
+        }
+
+        public WmiSearchResultItem Current
+        {
+            get
+            {
+                IWbemClassObject** current = (IWbemClassObject**)_currentArrayHandle.Pointer;
+
+                return new(current[0]);
+            }
+        }
+
+        public bool MoveNext()
+        {
+            uint uReturn = 0;
+
+            if (_isCurrentInUse)
+            {
+                IWbemClassObject** current = (IWbemClassObject**)_currentArrayHandle.Pointer;
+                current[0]->Release();
+
+                _isCurrentInUse = false;
+            }
+
+            var array = (IWbemClassObject**)_currentArrayHandle.Pointer;
+
+            var hr = _enumerator->Next(_timeout, 1, array, &uReturn);
+
+            hr.ThrowOnFailure();
+
+            _isCurrentInUse = uReturn > 0;
+
+            return uReturn > 0;
+        }
+
+        public void Dispose()
+        {
+            if (_isCurrentInUse)
+            {
+                IWbemClassObject** current = (IWbemClassObject**)_currentArrayHandle.Pointer;
+                current[0]->Release();
+
+                _isCurrentInUse = false;
+            }
+
+            _currentArrayHandle.Dispose();
+        }
+    }
+
+    public unsafe ref struct WmiSearch
+    {
+        private IWbemServices* _wbemServices;
+        private IWbemLocator* _wbemLocator;
+        private IEnumWbemClassObject* _wbemEnumerator;
+        private readonly int _timeout;
+
+        internal WmiSearch(IWbemServices* wbemServices, IWbemLocator* wbemLocator, IEnumWbemClassObject* wbemEnumerator, int timeout)
+        {
+            _wbemServices = wbemServices;
+            _wbemLocator = wbemLocator;
+            _wbemEnumerator = wbemEnumerator;
+            _timeout = timeout;
+        }
+
+        public WmiSearchResultsEnumerator GetEnumerator()
+        {
+            return new WmiSearchResultsEnumerator(_wbemEnumerator, _timeout);
+        }
+
+        public static WmiSearch Null => new WmiSearch();
+
+        public void Dispose()
+        {
+            _wbemServices->Release();
+            _wbemLocator->Release();
+            _wbemEnumerator->Release();
+        }
+    }
+}

--- a/Hardware.Info.Windows.Aot/NativeMethods.json
+++ b/Hardware.Info.Windows.Aot/NativeMethods.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://aka.ms/CsWin32.schema.json",
+  "allowMarshaling": false,
+  "comInterop": {
+    "preserveSigMethods": [ "*" ]
+  },
+  "public": false
+}

--- a/Hardware.Info.Windows.Aot/NativeMethods.txt
+++ b/Hardware.Info.Windows.Aot/NativeMethods.txt
@@ -1,0 +1,38 @@
+// COM initialization and security
+CoInitializeEx
+CoInitializeSecurity
+CoSetProxyBlanket
+CoUninitialize
+
+// WMI specific COM classes
+IWbemLocator
+IWbemServices
+IWbemClassObject
+IEnumWbemClassObject
+
+// COM helpers
+CoCreateInstance
+VARIANT
+VariantClear
+ClearVariantArray 
+BSTR
+SysAllocString
+SysFreeString
+
+VariantToUInt16Array
+VariantToStringArray
+
+VariantToInt16
+VariantToInt32
+VariantToString 
+VariantToUInt16
+VariantToUInt32
+VariantToUInt64
+VariantToBoolean
+VariantToInt32Array
+
+// Other functions
+GlobalMemoryStatusEx
+MEMORYSTATUSEX
+RtlGetVersion
+OSVERSIONINFOEXW

--- a/Hardware.Info.sln
+++ b/Hardware.Info.sln
@@ -1,13 +1,17 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.30104.148
+# Visual Studio Version 17
+VisualStudioVersion = 17.11.35312.102
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Hardware.Info", "Hardware.Info\Hardware.Info.csproj", "{A3F91D8E-1DF9-471C-9BBE-99A76881A419}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Hardware.Info.Test", "Hardware.Info.Test\Hardware.Info.Test.csproj", "{37D3CEB9-DB5B-4424-A033-52F8AB5C8F62}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Hardware.Info.Benchmark", "Hardware.Info.Benchmark\Hardware.Info.Benchmark.csproj", "{1E3DFEB6-2E9B-4BA3-B7FF-4AC79D62F014}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Hardware.Info.Windows.Aot", "Hardware.Info.Windows.Aot\Hardware.Info.Windows.Aot.csproj", "{6870B02A-3573-4E09-B240-B2FD0CE11345}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Hardware.Info.TestAot", "Hardware.Info.TestAot\Hardware.Info.TestAot.csproj", "{3AE77836-DFF6-4690-B29B-C619B9D2A629}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -27,6 +31,14 @@ Global
 		{1E3DFEB6-2E9B-4BA3-B7FF-4AC79D62F014}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{1E3DFEB6-2E9B-4BA3-B7FF-4AC79D62F014}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{1E3DFEB6-2E9B-4BA3-B7FF-4AC79D62F014}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6870B02A-3573-4E09-B240-B2FD0CE11345}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6870B02A-3573-4E09-B240-B2FD0CE11345}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6870B02A-3573-4E09-B240-B2FD0CE11345}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6870B02A-3573-4E09-B240-B2FD0CE11345}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3AE77836-DFF6-4690-B29B-C619B9D2A629}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3AE77836-DFF6-4690-B29B-C619B9D2A629}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3AE77836-DFF6-4690-B29B-C619B9D2A629}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3AE77836-DFF6-4690-B29B-C619B9D2A629}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Hardware.Info/HardwareInfo.cs
+++ b/Hardware.Info/HardwareInfo.cs
@@ -118,6 +118,11 @@ namespace Hardware.Info
             }
         }
 
+        public HardwareInfo(IHardwareInfoRetrieval implementation)
+        {
+            _hardwareInfoRetrieval = implementation;
+        }
+
         /// <summary>
         /// Refresh all hardware info
         /// </summary>

--- a/Hardware.Info/HardwareInfoBase.cs
+++ b/Hardware.Info/HardwareInfoBase.cs
@@ -8,9 +8,9 @@ using System.Runtime.InteropServices;
 
 namespace Hardware.Info
 {
-    internal class HardwareInfoBase
+    public class HardwareInfoBase
     {
-        internal static Process StartProcess(string cmd, string args)
+        protected internal static Process StartProcess(string cmd, string args)
         {
             ProcessStartInfo processStartInfo = new ProcessStartInfo(cmd, args)
             {
@@ -24,7 +24,7 @@ namespace Hardware.Info
             return Process.Start(processStartInfo);
         }
 
-        internal static string ReadProcessOutput(string cmd, string args)
+        protected internal static string ReadProcessOutput(string cmd, string args)
         {
             try
             {
@@ -40,7 +40,7 @@ namespace Hardware.Info
             }
         }
 
-        internal static string TryReadTextFromFile(string path)
+        protected internal static string TryReadTextFromFile(string path)
         {
             try
             {
@@ -52,7 +52,7 @@ namespace Hardware.Info
             }
         }
 
-        internal static uint TryReadIntegerFromFile(params string[] possiblePaths)
+        protected internal static uint TryReadIntegerFromFile(params string[] possiblePaths)
         {
             foreach (string path in possiblePaths)
             {
@@ -67,7 +67,7 @@ namespace Hardware.Info
             return 0;
         }
 
-        internal static string[] TryReadLinesFromFile(string path)
+        protected internal static string[] TryReadLinesFromFile(string path)
         {
             try
             {

--- a/Hardware.Info/IHardwareInfoRetrieval.cs
+++ b/Hardware.Info/IHardwareInfoRetrieval.cs
@@ -2,7 +2,7 @@
 
 namespace Hardware.Info
 {
-    internal interface IHardwareInfoRetrieval
+    public interface IHardwareInfoRetrieval
     {
         OS GetOperatingSystem();
         MemoryStatus GetMemoryStatus();


### PR DESCRIPTION
Hi,

I wanted to share my proof of concept for aot support.
Under Windows, `Hardware.Info` uses WMI to gather hardware details. COM is used to interface with WMI. The "old" COM intertop in .net doesn't support aot compilation. Luckily com wrappers have been introduced which ["provide an optimized and AOT-friendly COM interop solution"](https://learn.microsoft.com/en-us/dotnet/standard/native-interop/tutorial-comwrappers).

This proof of concept is not ready to be merged as-is but shows that it's possible to to have both - WMI and aot.

## Changes
* `interface IHardwareInfoRetrieval` and `class HardwareInfoBase` are now public
* `class HardwareInfo` has a new constructor which accepts an instance of `IHardwareInfoRetrieval`
* Added new library `Hardware.Info.Windows.Aot` which implements `class HardwareInfoRetrievalWindowsAot`
* Added copy of `Hardware.Info.TestAot` which enables aot publication and uses  `Hardware.Info.Windows.Aot`

My goal has been to compare both implementations (old COM interop and new COM wrappers). Aot support should be a drop-in solution and not require any other changes. Therefore I made `interface IHardwareInfoRetrieval` and `class HardwareInfoBase` are public. 

## Next Steps
If aot support is a viable path forward, I suggest that
* Aot support is provided as separate pre-release package - early adapters can opt-in and share feedback. I am not a aot expert and there might be some quirks (see section about current issues for more details)
* Move current windows implementation into a separate library. `Hardware.Info` still references non-aot compatible packages. I think that's fine as long as the code paths aren't used - they might actually be trimmed out when trimming is enabled. But this should be investigated to prevent issues for users. Moving the windows implementation out into a separate library would avoid all these issues but that's a breaking change.
* The code still needs some clean up and refactoring - it's just a proof of concept after all.
* Check how `System.Management` initializes and un-initializes com (see issues section).
* Some research how to properly mark a package as aot compatible and trimmable.
* Better error handling, no more `Console.WriteLine`

## Issues
* The library still needs to initialize com. As far as I understand, this can (should?) only be done once. How this could be checked - I do not know
* Currently com is un-initialized on clean up - this might no be desired.
- This is not related to oat but I've noticed that several big numeric properties (like filesystem size) could cause an integer overflow. WMI exposes these fields as strings and they are parsed into (long) integers. `System.Numerics.BigInteger` might be a better alternative - but that's a breaking change. 
