### PR TITLE
Add includePerformanceCounter flag to GetCpuList() method

### DIFF
--- a/Hardware.Info/IHardwareInfoRetrieval.cs
+++ b/Hardware.Info/IHardwareInfoRetrieval.cs
@@ -10,7 +10,7 @@ namespace Hardware.Info
         List<Battery> GetBatteryList();
         List<BIOS> GetBiosList();
         List<ComputerSystem> GetComputerSystemList();
-        List<CPU> GetCpuList(bool includePercentProcessorTime = true, int millisecondsDelayBetweenTwoMeasurements = 500);
+        List<CPU> GetCpuList(bool includePercentProcessorTime = true, int millisecondsDelayBetweenTwoMeasurements = 500, bool includePerformanceCounter = false);
         List<Drive> GetDriveList();
         List<Keyboard> GetKeyboardList();
         List<Memory> GetMemoryList();

--- a/Hardware.Info/Windows/HardwareInfoRetrieval.cs
+++ b/Hardware.Info/Windows/HardwareInfoRetrieval.cs
@@ -266,7 +266,7 @@ namespace Hardware.Info.Windows
             return computerSystemList;
         }
 
-        public List<CPU> GetCpuList(bool includePercentProcessorTime = true, int millisecondsDelayBetweenTwoMeasurements = 500)
+        public List<CPU> GetCpuList(bool includePercentProcessorTime = true, int millisecondsDelayBetweenTwoMeasurements = 500, bool includePerformanceCounter = true)
         {
             List<CPU> cpuList = new List<CPU>();
 
@@ -331,16 +331,20 @@ namespace Hardware.Info.Windows
 
             float processorPerformance = 100f;
 
-            try
+            if (includePerformanceCounter)
             {
-                using PerformanceCounter cpuCounter = new PerformanceCounter("Processor Information", "% Processor Performance", "_Total");
-                processorPerformance = cpuCounter.NextValue();
-                System.Threading.Thread.Sleep(1); // the first call to NextValue() always returns 0
-                processorPerformance = cpuCounter.NextValue();
-            }
-            catch
-            {
-                // Ignore performance counter errors and just assume that it's at 100 %
+                try
+                {
+                    using PerformanceCounter cpuCounter =
+                        new PerformanceCounter("Processor Information", "% Processor Performance", "_Total");
+                    processorPerformance = cpuCounter.NextValue();
+                    System.Threading.Thread.Sleep(1); // the first call to NextValue() always returns 0
+                    processorPerformance = cpuCounter.NextValue();
+                }
+                catch
+                {
+                    // Ignore performance counter errors and just assume that it's at 100 %
+                }
             }
 
             uint L1InstructionCacheSize = 0;


### PR DESCRIPTION
This PR introduces a new optional parameter, includePerformanceCounter, to the existing method GetCpuList(). When set to false, the method will skip the legacy PerformanceCounter call (thus avoiding any dependency on msvcr80.dll).

Resolves: https://github.com/Jinjinov/Hardware.Info/issues/81
