### PR TITLE
IDisposable

### DIFF
--- a/Hardware.Info.Aot.Test/Program.cs
+++ b/Hardware.Info.Aot.Test/Program.cs
@@ -14,7 +14,7 @@ namespace Hardware.Info.Test
 
         static void Test(bool test)
         {
-            IHardwareInfo hardwareInfo = new HardwareInfo();
+            using IHardwareInfo hardwareInfo = new HardwareInfo();
 
             hardwareInfo.RefreshOperatingSystem();
             hardwareInfo.RefreshMemoryStatus();

--- a/Hardware.Info.Aot/Windows/WmiLightObjectAdapter.cs
+++ b/Hardware.Info.Aot/Windows/WmiLightObjectAdapter.cs
@@ -11,5 +11,7 @@ namespace Hardware.Info.Windows
         public object this[string propertyName] => _inner[propertyName];
 
         public WmiObject GetWmiObject() => _inner;
+
+        public void Dispose() => _inner.Dispose();
     }
 }

--- a/Hardware.Info.Aot/Windows/WmiLightQueryProvider.cs
+++ b/Hardware.Info.Aot/Windows/WmiLightQueryProvider.cs
@@ -43,7 +43,7 @@ namespace Hardware.Info.Windows
                 _wmiConnectionDict[scope] = wmiConnection;
             }
 
-            WmiLightObjectAdapter? wmiLightObjectAdapter = wmiPropertySource as WmiLightObjectAdapter;
+            using WmiLightObjectAdapter? wmiLightObjectAdapter = wmiPropertySource as WmiLightObjectAdapter;
 
             if (wmiLightObjectAdapter is null)
                 yield break;
@@ -60,6 +60,15 @@ namespace Hardware.Info.Windows
                 foreach (WmiObject mo in wmiConnection.CreateQueryForRelated(wmiObject, relatedClass))
                     yield return new WmiLightObjectAdapter(mo);
             }
+        }
+
+        public void Dispose()
+        {
+            foreach (var wmiConnection in _wmiConnectionDict.Values)
+            {
+                wmiConnection.Dispose();
+            }
+            _wmiConnectionDict.Clear();
         }
     }
 }

--- a/Hardware.Info.Core/HardwareInfoBase.cs
+++ b/Hardware.Info.Core/HardwareInfoBase.cs
@@ -216,6 +216,11 @@ namespace Hardware.Info
         /// </summary>
         public void RefreshVideoControllerList() => VideoControllerList = _platformHardwareInfo.GetVideoControllerList();
 
+        public void Dispose()
+        {
+            _platformHardwareInfo.Dispose();
+        }
+
         #region Static
 
         private static bool _pingInProgress;

--- a/Hardware.Info.Core/IHardwareInfo.cs
+++ b/Hardware.Info.Core/IHardwareInfo.cs
@@ -1,11 +1,12 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 
 namespace Hardware.Info
 {
     /// <summary>
     /// Main Hardware.Info interface
     /// </summary>
-    public interface IHardwareInfo
+    public interface IHardwareInfo : IDisposable
     {
         /// <summary>
         /// Operating system

--- a/Hardware.Info.Core/IPlatformHardwareInfo.cs
+++ b/Hardware.Info.Core/IPlatformHardwareInfo.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("Hardware.Info, PublicKey=0024000004800000940000000602000000240000525341310004000001000100f9caba3b554c3c962fd85b3722680234d5f5ca2abec47a345a22e9f11e5abbb6c480c7b3506c1d493732056c439f9bee9f79e8f4d67ce6c1104ea88cc4c0273e6c85612e5a0f8d9aca97454da75c92817874a1d18d89fa97de1fab64c8e000f44350a0142486bf0b16e767fc4f2daefe1a6f062467f79e59d969899540a93bdf")]
@@ -6,7 +7,7 @@ using System.Runtime.CompilerServices;
 
 namespace Hardware.Info
 {
-    public interface IPlatformHardwareInfo
+    public interface IPlatformHardwareInfo : IDisposable
     {
         OS GetOperatingSystem();
         MemoryStatus GetMemoryStatus();

--- a/Hardware.Info.Core/Linux/PlatformHardwareInfo.cs
+++ b/Hardware.Info.Core/Linux/PlatformHardwareInfo.cs
@@ -4,7 +4,6 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Net;
-using System.Net.NetworkInformation;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 
@@ -1232,6 +1231,10 @@ namespace Hardware.Info.Linux
             }
 
             return videoControllerList;
+        }
+
+        public void Dispose()
+        {
         }
     }
 }

--- a/Hardware.Info.Core/Mac/PlatformHardwareInfo.cs
+++ b/Hardware.Info.Core/Mac/PlatformHardwareInfo.cs
@@ -1309,5 +1309,9 @@ Graphics/Displays:
 
             return videoControllerList;
         }
+
+        public void Dispose()
+        {
+        }
     }
 }

--- a/Hardware.Info.Core/Windows/IWmiPropertySource.cs
+++ b/Hardware.Info.Core/Windows/IWmiPropertySource.cs
@@ -1,6 +1,8 @@
-﻿namespace Hardware.Info.Windows
+﻿using System;
+
+namespace Hardware.Info.Windows
 {
-    internal interface IWmiPropertySource
+    internal interface IWmiPropertySource : IDisposable
     {
         object this[string propertyName] { get; }
     }

--- a/Hardware.Info.Core/Windows/IWmiQueryProvider.cs
+++ b/Hardware.Info.Core/Windows/IWmiQueryProvider.cs
@@ -1,8 +1,9 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 
 namespace Hardware.Info.Windows
 {
-    internal interface IWmiQueryProvider
+    internal interface IWmiQueryProvider : IDisposable
     {
         IEnumerable<IWmiPropertySource> Query(string scope, string query);
 

--- a/Hardware.Info.Core/Windows/PlatformHardwareInfo.cs
+++ b/Hardware.Info.Core/Windows/PlatformHardwareInfo.cs
@@ -92,6 +92,8 @@ namespace Hardware.Info.Windows
 
             foreach (IWmiPropertySource mo in _wmiQueryProvider.Query(_managementScope, queryString))
             {
+                using var _ = mo;
+
                 _os.Name = GetPropertyString(mo["Caption"]);
                 _os.VersionString = GetPropertyString(mo["Version"]);
 
@@ -188,6 +190,8 @@ namespace Hardware.Info.Windows
 
             foreach (IWmiPropertySource mo in _wmiQueryProvider.Query(_managementScope, queryString))
             {
+                using var _ = mo;
+
                 Battery battery = new Battery
                 {
                     FullChargeCapacity = GetPropertyValue<uint>(mo["FullChargeCapacity"]),
@@ -215,6 +219,8 @@ namespace Hardware.Info.Windows
 
             foreach (IWmiPropertySource mo in _wmiQueryProvider.Query(_managementScope, queryString))
             {
+                using var _ = mo;
+
                 BIOS bios = new BIOS
                 {
                     Caption = GetPropertyString(mo["Caption"]),
@@ -241,6 +247,8 @@ namespace Hardware.Info.Windows
 
             foreach (IWmiPropertySource mo in _wmiQueryProvider.Query(_managementScope, queryString))
             {
+                using var _ = mo;
+
                 ComputerSystem computerSystem = new ComputerSystem
                 {
                     Caption = GetPropertyString(mo["Caption"]),
@@ -277,6 +285,8 @@ namespace Hardware.Info.Windows
                 {
                     foreach (IWmiPropertySource mo in _wmiQueryProvider.Query(_managementScope, queryString))
                     {
+                        using var _ = mo;
+
                         CpuCore core = new CpuCore
                         {
                             Name = GetPropertyString(mo["Name"]),
@@ -288,6 +298,8 @@ namespace Hardware.Info.Windows
 
                     foreach (IWmiPropertySource mo in _wmiQueryProvider.Query(_managementScope, totalQueryString))
                     {
+                        using var _ = mo;
+
                         percentProcessorTime = GetPropertyValue<ulong>(mo["PercentProcessorTime"]);
                     }
                 }
@@ -302,6 +314,8 @@ namespace Hardware.Info.Windows
 
                     foreach (IWmiPropertySource mo in _wmiQueryProvider.Query(_managementScope, processorQueryString))
                     {
+                        using var _ = mo;
+
                         percentProcessorTime = GetPropertyValue<ushort>(mo["LoadPercentage"]);
                     }
                 }
@@ -343,6 +357,8 @@ namespace Hardware.Info.Windows
             // Unified = 5
             foreach (IWmiPropertySource mo in _wmiQueryProvider.Query(_managementScope, cacheMemoryquery))
             {
+                using var _ = mo;
+
                 ushort CacheType = GetPropertyValue<ushort>(mo["CacheType"]);
                 uint MaxCacheSize = 1024 * GetPropertyValue<uint>(mo["MaxCacheSize"]);
 
@@ -363,6 +379,8 @@ namespace Hardware.Info.Windows
 
             foreach (IWmiPropertySource mo in _wmiQueryProvider.Query(_managementScope, processorQuery))
             {
+                using var _ = mo;
+
                 uint maxClockSpeed = GetPropertyValue<uint>(mo["MaxClockSpeed"]);
 
                 uint currentClockSpeed = (uint)(maxClockSpeed * (processorPerformance / 100));
@@ -409,6 +427,8 @@ namespace Hardware.Info.Windows
 
             foreach (IWmiPropertySource DiskDrive in _wmiQueryProvider.Query(_managementScope, diskDriveQueryString))
             {
+                using var _ = DiskDrive;
+
                 Drive drive = new Drive
                 {
                     Caption = GetPropertyString(DiskDrive["Caption"]),
@@ -428,6 +448,8 @@ namespace Hardware.Info.Windows
 
                 foreach (IWmiPropertySource DiskPartition in _wmiQueryProvider.Query(_managementScope, diskPartitionQueryString))
                 {
+                    using var __ = DiskPartition;
+
                     Partition partition = new Partition
                     {
                         Bootable = GetPropertyValue<bool>(DiskPartition["Bootable"]),
@@ -446,6 +468,8 @@ namespace Hardware.Info.Windows
 
                     foreach (IWmiPropertySource LogicalDisk in _wmiQueryProvider.Query(_managementScope, logicalDiskQueryString))
                     {
+                        using var ___ = LogicalDisk;
+
                         Volume volume = new Volume
                         {
                             Caption = GetPropertyString(LogicalDisk["Caption"]),
@@ -479,6 +503,8 @@ namespace Hardware.Info.Windows
 
             foreach (IWmiPropertySource mo in _wmiQueryProvider.Query(_managementScope, queryString))
             {
+                using var _ = mo;
+
                 Keyboard keyboard = new Keyboard
                 {
                     Caption = GetPropertyString(mo["Caption"]),
@@ -502,6 +528,8 @@ namespace Hardware.Info.Windows
 
             foreach (IWmiPropertySource mo in _wmiQueryProvider.Query(_managementScope, queryString))
             {
+                using var _ = mo;
+
                 Memory memory = new Memory
                 {
                     BankLabel = GetPropertyString(mo["BankLabel"]),
@@ -518,7 +546,7 @@ namespace Hardware.Info.Windows
                 {
                     memory.MaxVoltage = GetPropertyValue<uint>(mo["MaxVoltage"]);
                     memory.MinVoltage = GetPropertyValue<uint>(mo["MinVoltage"]);
-                    
+
                     memory.MemoryType = (MemoryType)GetPropertyValue<uint>(mo["SMBIOSMemoryType"]);
                 }
 
@@ -536,6 +564,8 @@ namespace Hardware.Info.Windows
 
             foreach (IWmiPropertySource win32PnpEntityMo in _wmiQueryProvider.Query(_managementScope, win32PnpEntityQuery))
             {
+                using var _ = win32PnpEntityMo;
+
                 try
                 {
                     string deviceId = GetPropertyString(win32PnpEntityMo["DeviceId"]);
@@ -543,8 +573,8 @@ namespace Hardware.Info.Windows
 
                     string wmiMonitorIdQuery = $"SELECT Active, ProductCodeID, SerialNumberID, ManufacturerName, UserFriendlyName, WeekOfManufacture, YearOfManufacture FROM WmiMonitorID WHERE InstanceName LIKE '{deviceId}%'".Replace(@"\", "_");
 
-                    IWmiPropertySource? desktopMonitorMo = _wmiQueryProvider.Query(_managementScope, win32DesktopMonitorQuery).FirstOrDefault();
-                    IWmiPropertySource? wmiMonitorIdMo = _wmiQueryProvider.Query(_managementScopeWmi, wmiMonitorIdQuery).FirstOrDefault();
+                    using IWmiPropertySource? desktopMonitorMo = _wmiQueryProvider.Query(_managementScope, win32DesktopMonitorQuery).FirstOrDefault();
+                    using IWmiPropertySource? wmiMonitorIdMo = _wmiQueryProvider.Query(_managementScopeWmi, wmiMonitorIdQuery).FirstOrDefault();
 
                     Monitor monitor = new Monitor();
 
@@ -588,6 +618,8 @@ namespace Hardware.Info.Windows
 
             foreach (IWmiPropertySource mo in _wmiQueryProvider.Query(_managementScope, queryString))
             {
+                using var _ = mo;
+
                 Motherboard motherboard = new Motherboard
                 {
                     Manufacturer = GetPropertyString(mo["Manufacturer"]),
@@ -609,6 +641,8 @@ namespace Hardware.Info.Windows
 
             foreach (IWmiPropertySource mo in _wmiQueryProvider.Query(_managementScope, queryString))
             {
+                using var _ = mo;
+
                 Mouse mouse = new Mouse
                 {
                     Caption = GetPropertyString(mo["Caption"]),
@@ -632,6 +666,8 @@ namespace Hardware.Info.Windows
 
             foreach (IWmiPropertySource mo in _wmiQueryProvider.Query(_managementScope, queryString))
             {
+                using var _ = mo;
+
                 NetworkAdapter networkAdapter = new NetworkAdapter
                 {
                     AdapterType = GetPropertyString(mo["AdapterType"]),
@@ -655,6 +691,8 @@ namespace Hardware.Info.Windows
 
                     foreach (IWmiPropertySource managementObject in _wmiQueryProvider.Query(_managementScope, query))
                     {
+                        using var __ = managementObject;
+
                         networkAdapter.BytesSentPersec = GetPropertyValue<ulong>(managementObject["BytesSentPersec"]);
                         networkAdapter.BytesReceivedPersec = GetPropertyValue<ulong>(managementObject["BytesReceivedPersec"]);
 
@@ -671,6 +709,8 @@ namespace Hardware.Info.Windows
 
                     foreach (IWmiPropertySource configuration in _wmiQueryProvider.QueryRelated(_managementScope, mo, "Win32_NetworkAdapterConfiguration"))
                     {
+                        using var __ = configuration;
+
                         foreach (string str in GetPropertyArray<string>(configuration["DefaultIPGateway"]))
                             if (IPAddress.TryParse(str, out address))
                                 networkAdapter.DefaultIPGatewayList.Add(address);
@@ -706,6 +746,8 @@ namespace Hardware.Info.Windows
 
             foreach (IWmiPropertySource mo in _wmiQueryProvider.Query(_managementScope, queryString))
             {
+                using var _ = mo;
+
                 Printer printer = new Printer
                 {
                     Caption = GetPropertyString(mo["Caption"]),
@@ -733,6 +775,8 @@ namespace Hardware.Info.Windows
 
             foreach (IWmiPropertySource mo in _wmiQueryProvider.Query(_managementScope, queryString))
             {
+                using var _ = mo;
+
                 SoundDevice soundDevice = new SoundDevice
                 {
                     Caption = GetPropertyString(mo["Caption"]),
@@ -756,6 +800,8 @@ namespace Hardware.Info.Windows
 
             foreach (IWmiPropertySource mo in _wmiQueryProvider.Query(_managementScope, queryString))
             {
+                using var _ = mo;
+
                 VideoController videoController = new VideoController
                 {
                     Manufacturer = GetPropertyString(mo["AdapterCompatibility"]),
@@ -806,6 +852,11 @@ namespace Hardware.Info.Windows
             }
 
             return videoControllerList;
+        }
+
+        public void Dispose()
+        {
+            _wmiQueryProvider.Dispose();
         }
     }
 }

--- a/Hardware.Info.Test/Program.cs
+++ b/Hardware.Info.Test/Program.cs
@@ -14,7 +14,7 @@ namespace Hardware.Info.Test
 
         static void Test(bool test)
         {
-            IHardwareInfo hardwareInfo = new HardwareInfo();
+            using IHardwareInfo hardwareInfo = new HardwareInfo();
 
             hardwareInfo.RefreshOperatingSystem();
             hardwareInfo.RefreshMemoryStatus();

--- a/Hardware.Info/Windows/ManagementObjectAdapter.cs
+++ b/Hardware.Info/Windows/ManagementObjectAdapter.cs
@@ -11,5 +11,7 @@ namespace Hardware.Info.Windows
         public object this[string propertyName] => _inner[propertyName];
 
         public ManagementBaseObject GetManagementBaseObject() => _inner;
+
+        public void Dispose() => _inner.Dispose();
     }
 }

--- a/Hardware.Info/Windows/ManagementQueryProvider.cs
+++ b/Hardware.Info/Windows/ManagementQueryProvider.cs
@@ -24,9 +24,9 @@ namespace Hardware.Info.Windows
 
         public IEnumerable<IWmiPropertySource> QueryRelated(string scope, IWmiPropertySource wmiPropertySource, string relatedClass)
         {
-            ManagementObjectAdapter? managementObjectAdapter = wmiPropertySource as ManagementObjectAdapter;
+            using ManagementObjectAdapter? managementObjectAdapter = wmiPropertySource as ManagementObjectAdapter;
 
-            if(managementObjectAdapter is null)
+            if (managementObjectAdapter is null)
                 yield break;
 
             ManagementBaseObject managementBaseObject = managementObjectAdapter.GetManagementBaseObject();
@@ -38,6 +38,10 @@ namespace Hardware.Info.Windows
 
             foreach (ManagementBaseObject mo in managementObject.GetRelated(relatedClass))
                 yield return new ManagementObjectAdapter(mo);
+        }
+
+        public void Dispose()
+        {
         }
     }
 }


### PR DESCRIPTION
This makes `IHardwareInfo` and all other required interfaces / classes `IDisposable` to dispose the cached WmiConnection in AOT project.
Also makes `IWmiPropertySource` `IDisposable` to dispose `ManagementBaseObject` and `WmiObject`.

See #94 